### PR TITLE
Add LLM service (Gemini API) to frontend

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,10 +33,10 @@ cd lit
 npm install
 ```
 
-Then, set up a Firebase config (fork the example and fill in details):
+Then, set up Firebase and LLM config (fork the example and fill in details):
 
 ```bash
-cp src/shared/firebase_config_example.ts src/shared/firebase_config.ts
+cp src/shared/config_example.ts src/shared/config.ts
 ```
 
 Finally, run the app (with live reload):

--- a/lit/.gitignore
+++ b/lit/.gitignore
@@ -16,3 +16,4 @@ npm-debug.log*
 app.yaml
 
 firebase_config.ts
+config.ts

--- a/lit/README.md
+++ b/lit/README.md
@@ -1,4 +1,4 @@
-# Lit Frontend
+  # Lit Frontend
 
 This directory contains a Lit Element / MobX frontend for the LLM Mediation
 Experiments project.
@@ -8,7 +8,7 @@ Experiments project.
 To run locally:
 
 ```
-cp src/shared/firebase_config_example.ts src/shared/firebase_config.ts
+cp src/shared/config_example.ts src/shared/config.ts
 npm run start
 ```
 
@@ -42,7 +42,22 @@ The actual rendering of different pages happens in `app.ts`.
 The `header` and `sidenav` components (under `src/components`) also notably
 contain routing logic.
 
+### LLM API
+
+Lit currently uses Google's [Gemini API](https://ai.google.dev/gemini-api)
+(you will need your own API key).
+
+Set up config under `src/shared/config.ts`
+(fork from `src/shared/config_example.ts`).
+
+The following LLM service manages calls to Gemini API:
+
+`src/services/llm_service.ts`
+
 ### Firebase
+
+Set up config under `src/shared/config.ts`
+(fork from `src/shared/config_example.ts`).
 
 Services that interact with Firebase are organized at the
 `src/services` level and include:

--- a/lit/package-lock.json
+++ b/lit/package-lock.json
@@ -9,6 +9,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/lit-mobx": "^2.2.2",
+        "@google/generative-ai": "^0.13.0",
         "@llm-mediation-experiments/utils": "file:../utils",
         "@material/web": "^1.5.0",
         "@types/router5": "^5.0.0",
@@ -663,6 +664,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.0.tgz",
       "integrity": "sha512-zuWxyfXNbsKbm96HhXzainONPFqRcoZblQ++e9cAIGUuHfl2cFSBzW01jtesqWG/lqaUyX3H8O1y9oWboGNQBA=="
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.13.0.tgz",
+      "integrity": "sha512-F3rI52SbGS8bsFu4bWFfOPdtq91RsBzeVLsbJy/kt7zCuaBr28toR/8zS12zXjj6USIJd0rGeF2HsuPONUz+6w==",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.9.14",
@@ -7863,6 +7872,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.0.tgz",
       "integrity": "sha512-zuWxyfXNbsKbm96HhXzainONPFqRcoZblQ++e9cAIGUuHfl2cFSBzW01jtesqWG/lqaUyX3H8O1y9oWboGNQBA=="
+    },
+    "@google/generative-ai": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.13.0.tgz",
+      "integrity": "sha512-F3rI52SbGS8bsFu4bWFfOPdtq91RsBzeVLsbJy/kt7zCuaBr28toR/8zS12zXjj6USIJd0rGeF2HsuPONUz+6w=="
     },
     "@grpc/grpc-js": {
       "version": "1.9.14",

--- a/lit/package.json
+++ b/lit/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@adobe/lit-mobx": "^2.2.2",
+    "@google/generative-ai": "^0.13.0",
     "@llm-mediation-experiments/utils": "file:../utils",
     "@material/web": "^1.5.0",
     "@types/router5": "^5.0.0",

--- a/lit/src/app.ts
+++ b/lit/src/app.ts
@@ -257,8 +257,8 @@ export class App extends MobxLitElement {
       <div class="banner">
         <div>
           You are previewing as
-          ${participantName ? `${participantName} - ` : 'Participant '}
-          ${this.participantService.participantId}.
+          ${participantName ? `${participantName} / ` : 'Participant '}
+          ${this.participantService.profile?.publicId}.
         </div>
         <pr-button
           color="tertiary"

--- a/lit/src/experiment-components/chat/chat_message.scss
+++ b/lit/src/experiment-components/chat/chat_message.scss
@@ -51,6 +51,17 @@ $bubble-radius-small: common.$spacing-small;
   }
 }
 
+.mediator-bubble {
+  @include typescale.body-small;
+  align-items: end;
+  gap: common.$spacing-medium;
+  padding: common.$spacing-medium common.$spacing-large;
+  background: var(--md-sys-color-surface-container-high);
+  border-radius: $bubble-radius $bubble-radius $bubble-radius
+    $bubble-radius-small;
+  color: var(--md-sys-color-on-surface-container);
+}
+
 .discuss-message {
   @include common.flex-column-align-center;
   border-top: 1px solid var(--md-sys-color-surface);

--- a/lit/src/experiment-components/chat/chat_message.ts
+++ b/lit/src/experiment-components/chat/chat_message.ts
@@ -7,13 +7,16 @@ import { CSSResultGroup, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 
+import { DiscussItemsMessage, ITEMS, MediatorMessage, Message, MessageKind, UserMessage, getDefaultUserMessage } from "@llm-mediation-experiments/utils";
+import { Timestamp } from "firebase/firestore";
+
 import { core } from "../../core/core";
 import { ExperimentService } from "../../services/experiment_service";
 import { ParticipantService } from "../../services/participant_service";
 
+import { LLM_MEDIATOR_AVATAR } from "../../shared/constants";
+
 import { styles } from "./chat_message.scss";
-import { DiscussItemsMessage, ITEMS, MediatorMessage, Message, MessageKind, UserMessage, getDefaultUserMessage } from "@llm-mediation-experiments/utils";
-import { Timestamp } from "firebase/firestore";
 
 /** Chat message component */
 @customElement("chat-message")
@@ -72,10 +75,10 @@ export class ChatMessage extends MobxLitElement {
 
     return html`
       <div class=${classes}>
-        <div class="avatar"></div>
+        <profile-avatar .emoji=${LLM_MEDIATOR_AVATAR}></profile-avatar>
         <div class="content">
-          <div class="label">Mediator</div>
-          <div class="chat-bubble">${message.text}</div>
+          <div class="label">LLM Mediator</div>
+          <div class="mediator-bubble">${message.text}</div>
         </div>
       </div>
     `;

--- a/lit/src/experiment-components/survey/survey_preview.ts
+++ b/lit/src/experiment-components/survey/survey_preview.ts
@@ -48,7 +48,7 @@ export class SurveyPreview extends MobxLitElement {
       const answerMap = this.answer?.answers;
       const answerList = answerMap ? Object.values(answerMap) : [];
 
-      return (answerList.map(
+      return (answerList.filter(
         answer => answer.kind === SurveyQuestionKind.Rating).length) ===
         (this.stage?.questions.filter(
         question => question.kind === SurveyQuestionKind.Rating).length)

--- a/lit/src/service_provider.ts
+++ b/lit/src/service_provider.ts
@@ -4,6 +4,7 @@ import { ChatService } from "./services/chat_service";
 import { ExperimentService } from "./services/experiment_service";
 import { FirebaseService } from "./services/firebase_service";
 import { InitializationService } from "./services/initialization_service";
+import { LLMService } from "./services/llm_service";
 import { RouterService } from "./services/router_service";
 import { SettingsService } from "./services/settings_service";
 
@@ -31,6 +32,9 @@ export function makeServiceProvider(self: Core) {
     },
     get firebaseService() {
       return self.getService(FirebaseService);
+    },
+    get llmService() {
+      return self.getService(LLMService);
     },
     get authService() {
       return self.getService(AuthService);

--- a/lit/src/services/chat_service.ts
+++ b/lit/src/services/chat_service.ts
@@ -188,8 +188,13 @@ export class ChatService extends Service {
       this.sp.experimentService.getParticipantProfiles().map(p => p.publicId)
     );
 
-    // TODO: Create message response if appropriate
-    const reponse = this.sp.llmService.call(prompt);
+    await this.sp.llmService.call(prompt).then(modelResponse => {
+      // If no new messages have been sent, convert LLM response to
+      // new mediator chat message.
+      if (this.messages.length <= messages.length) {
+        this.sendMediatorMessage(modelResponse.text);
+      }
+    });
   }
 
   /** Send a message as a mediator.

--- a/lit/src/services/firebase_service.ts
+++ b/lit/src/services/firebase_service.ts
@@ -23,7 +23,7 @@ import {
     FIREBASE_LOCAL_HOST_PORT_FIRESTORE,
     FIREBASE_LOCAL_HOST_PORT_FUNCTIONS
 } from '../shared/constants';
-import { FIREBASE_CONFIG } from '../shared/config';
+import { FIREBASE_CONFIG } from '../shared/config_example';
 
 import { Service } from "./service";
 

--- a/lit/src/services/firebase_service.ts
+++ b/lit/src/services/firebase_service.ts
@@ -23,7 +23,7 @@ import {
     FIREBASE_LOCAL_HOST_PORT_FIRESTORE,
     FIREBASE_LOCAL_HOST_PORT_FUNCTIONS
 } from '../shared/constants';
-import { FIREBASE_CONFIG } from '../shared/firebase_config';
+import { FIREBASE_CONFIG } from '../shared/config';
 
 import { Service } from "./service";
 

--- a/lit/src/services/llm_service.ts
+++ b/lit/src/services/llm_service.ts
@@ -1,0 +1,134 @@
+import { ModelResponse } from "../shared/types";
+import { LLM_CONFIG } from "../shared/config";
+import { Service } from "./service";
+import {
+  GoogleGenerativeAI,
+  GenerationConfig,
+  HarmCategory,
+  HarmBlockThreshold,
+} from "@google/generative-ai";
+
+const DEFAULT_FETCH_TIMEOUT = 300 * 1000; // This is the Chrome default
+const MAX_TOKENS_FINISH_REASON = "MAX_TOKENS";
+const QUOTA_ERROR_CODE = 429;
+
+interface CallPredictRequest {
+  prompt: string;
+}
+
+const SAFETY_SETTINGS = [
+  {
+    category: HarmCategory.HARM_CATEGORY_HARASSMENT,
+    threshold: HarmBlockThreshold.BLOCK_ONLY_HIGH,
+  },
+  {
+    category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+    threshold: HarmBlockThreshold.BLOCK_ONLY_HIGH,
+  },
+  {
+    category: HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+    threshold: HarmBlockThreshold.BLOCK_ONLY_HIGH,
+  },
+  {
+    category: HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+    threshold: HarmBlockThreshold.BLOCK_ONLY_HIGH,
+  },
+];
+
+/**
+ * Handles LLM API requests.
+ */
+export class LLMService extends Service {
+  genAI: GoogleGenerativeAI;
+
+  constructor() {
+    super();
+    this.genAI = new GoogleGenerativeAI(LLM_CONFIG["apiKey"]);
+  }
+
+  async callGemini(
+    prompt: string,
+    generationConfig: GenerationConfig,
+    modelName = "gemini-1.5-pro-latest"
+  ) {
+    const model = this.genAI.getGenerativeModel({
+      model: modelName,
+      generationConfig,
+      safetySettings: SAFETY_SETTINGS,
+    });
+
+    const result = await model.generateContent(prompt);
+    const response = await result.response;
+
+    if (!response || !response.candidates) {
+      console.log('Error: No response');
+      return { text: '' };
+    }
+
+    const finishReason = response.candidates[0].finishReason;
+    if (finishReason === MAX_TOKENS_FINISH_REASON) {
+      console.log(
+        `Error: Token limit (${generationConfig.maxOutputTokens}) exceeded`
+      );
+    }
+
+    return { text: response.text() };
+  }
+
+  async call(
+    promptText: string,
+    stopTokens: string[] = [],
+    temperature = 0.5,
+    topP = 0.1,
+    topK = 16
+  ): Promise<ModelResponse> {
+    const apiKey = LLM_CONFIG["apiKey"];
+    const modelName = LLM_CONFIG["modelName"];
+    const maxTokens = LLM_CONFIG["maxTokens"];
+
+    // Log the request
+    console.log(
+      "call",
+      "prompt:",
+      promptText,
+      "stopTokens:",
+      stopTokens,
+      "maxTokens:",
+      maxTokens
+    );
+
+    const request: CallPredictRequest = {
+      prompt: `${promptText} {{ llm(stop=[${stopTokens
+        .map((token) => `"${token}"`)
+        .join(",")}], max_tokens=${maxTokens}) }}`,
+    };
+
+    const generationConfig = {
+      stopSequences: stopTokens,
+      maxOutputTokens: maxTokens,
+      temperature,
+      topP,
+      topK,
+    };
+
+    let response = { text: "" };
+    try {
+      response = await this.callGemini(
+        promptText,
+        generationConfig,
+        modelName
+      );
+    } catch (error: any) {
+      if (error.message.includes(QUOTA_ERROR_CODE.toString())) {
+        console.log("API quota exceeded");
+      } else {
+        console.log("API error");
+      }
+      console.log(error);
+    }
+
+    // Log the response
+    console.log(response);
+    return response;
+  }
+}

--- a/lit/src/shared/config_example.ts
+++ b/lit/src/shared/config_example.ts
@@ -8,3 +8,9 @@ export const FIREBASE_CONFIG: FirebaseOptions = {
   messagingSenderId: 'your-messaging-sender-id',
   appId: 'your-app-id',
 };
+
+export const LLM_CONFIG = {
+  apiKey: 'your-api-key',
+  modelName: 'gemini-pro',
+  maxTokens: 300,
+};

--- a/lit/src/shared/constants.ts
+++ b/lit/src/shared/constants.ts
@@ -25,3 +25,6 @@ export const PROFILE_AVATARS = [
   '👨🏻','👨🏼','👨🏽','👨🏾','👨🏿',
   '🧑🏻','🧑🏼','🧑🏽','🧑🏾','🧑🏿'
 ];
+
+/** LLM mediator avatar. */
+export const LLM_MEDIATOR_AVATAR = '🤖';

--- a/lit/src/shared/prompts.ts
+++ b/lit/src/shared/prompts.ts
@@ -2,14 +2,19 @@
  * Types, constants, and functions for LLM prompts.
  */
 
-import { Message, MessageKind } from '@llm-mediation-experiments/utils';
+import { ITEMS, Message, MessageKind } from '@llm-mediation-experiments/utils';
 
 /** Instructions for chat mediator prompt. */
 // TODO: Update placeholder prompt
 export const PROMPT_INSTRUCTIONS_CHAT_MEDIATOR = `
-  Summarize the following chat messages in less than 5 sentences.
-  Note whether or not all participants spoke for an equal amount of time
-  (and if not, which ones spoke the least)
+  You are the moderator for a group chat where the participants are
+  deciding which items will be useful while lost at sea.
+  For each topic of discussion, the participants will debate between
+  two items.
+
+  Respond with a 2 sentence summary of the current discussion.
+  Reference participants using the {participant-0} format.
+  Note anyone who did not get to speak or anyone who was rude.
 `;
 
 /** Create LLM chat mediator prompt. */
@@ -19,11 +24,9 @@ export function createChatMediatorPrompt(
   const formatMessage = (message: Message) => {
     switch (message.kind) {
       case MessageKind.UserMessage:
-        return `${message.fromPublicParticipantId}: ${message.text}`;
+        return `{${message.fromPublicParticipantId}}: ${message.text}`;
       case MessageKind.DiscussItemsMessage:
-        return `New discussion: ${message.itemPair.item1}, ${message.itemPair.item2}`;
-      case MessageKind.MediatorMessage:
-        return `LLM Mediator: ${message.text}`;
+        return `Discussion topic: ${ITEMS[message.itemPair.item1].name}, ${ITEMS[message.itemPair.item2].name}`;
       default:
         return '';
     }
@@ -33,12 +36,12 @@ export function createChatMediatorPrompt(
     ${PROMPT_INSTRUCTIONS_CHAT_MEDIATOR}
 
     [Participants]
-    ${participants.join(', ')}
+    ${participants.join(',')}
 
-    [Chat messages]
+    [Chat history]
     ${messages.map(message => formatMessage(message)).join('\n\n')}
 
-    [Summary]
+    [Moderator response]
   `;
 
   return prompt;

--- a/lit/src/shared/prompts.ts
+++ b/lit/src/shared/prompts.ts
@@ -1,0 +1,45 @@
+/**
+ * Types, constants, and functions for LLM prompts.
+ */
+
+import { Message, MessageKind } from '@llm-mediation-experiments/utils';
+
+/** Instructions for chat mediator prompt. */
+// TODO: Update placeholder prompt
+export const PROMPT_INSTRUCTIONS_CHAT_MEDIATOR = `
+  Summarize the following chat messages in less than 5 sentences.
+  Note whether or not all participants spoke for an equal amount of time
+  (and if not, which ones spoke the least)
+`;
+
+/** Create LLM chat mediator prompt. */
+export function createChatMediatorPrompt(
+  messages: Message[], participants: string[]
+) {
+  const formatMessage = (message: Message) => {
+    switch (message.kind) {
+      case MessageKind.UserMessage:
+        return `${message.fromPublicParticipantId}: ${message.text}`;
+      case MessageKind.DiscussItemsMessage:
+        return `New discussion: ${message.itemPair.item1}, ${message.itemPair.item2}`;
+      case MessageKind.MediatorMessage:
+        return `LLM Mediator: ${message.text}`;
+      default:
+        return '';
+    }
+  };
+
+  const prompt = `
+    ${PROMPT_INSTRUCTIONS_CHAT_MEDIATOR}
+
+    [Participants]
+    ${participants.join(', ')}
+
+    [Chat messages]
+    ${messages.map(message => formatMessage(message)).join('\n\n')}
+
+    [Summary]
+  `;
+
+  return prompt;
+}

--- a/lit/src/shared/types.ts
+++ b/lit/src/shared/types.ts
@@ -30,3 +30,11 @@ export enum TextSize {
   MEDIUM = "medium",
   LARGE = "large",
 }
+
+/**
+ * LLM API model response
+ */
+export interface ModelResponse {
+  score?: number;
+  text: string;
+}


### PR DESCRIPTION
This sets up ChatService to query the Gemini API for an LLM mediator response after each new chat message and (if no other chat messages have been sent in the meantime) converts that response to a mediator chat message.

> Note: This uses a placeholder prompt, which we'll have to update for real mediation :)

![image](https://github.com/PAIR-code/llm-mediation-experiments/assets/80003560/8124c01f-6645-4b12-9211-d0a8eb3b8250)

Fixes #51 