### PR TITLE
Update UX for configuring experiment metadata

### DIFF
--- a/lit/src/components/header/header.scss
+++ b/lit/src/components/header/header.scss
@@ -23,6 +23,12 @@
   gap: common.$spacing-small;
   justify-content: space-between;
   padding: common.$spacing-medium;
+
+  .left,
+  .right {
+    @include common.flex-row-align-center;
+    gap: common.$spacing-medium;
+  }
 }
 
 .header {

--- a/lit/src/components/header/header.ts
+++ b/lit/src/components/header/header.ts
@@ -50,6 +50,23 @@ export class Header extends MobxLitElement {
     `;
   }
 
+  private renderEditPermissions() {
+    const toggleEdit = () => {
+      this.authService.setEditPermissions(!this.authService.canEdit);
+    };
+
+    return html`
+      <pr-tooltip text="Toggle edit permissions" position="BOTTOM_END">
+        <pr-icon-button
+          icon=${this.authService.canEdit ? 'edit_off' : 'edit'}
+          color="primary"
+          variant="default"
+          @click=${toggleEdit}>
+        </pr-icon-button>
+      </pr-tooltip>
+    `;
+  }
+
   private renderAuthBanner() {
     if (!this.authService.isExperimenter
       || !this.routerService.isParticipantPage) {
@@ -61,6 +78,7 @@ export class Header extends MobxLitElement {
         Pages.EXPERIMENT,
         { "experiment": this.routerService.activeRoute.params["experiment"] }
       );
+      this.authService.setEditPermissions(false);
       this.routerService.setExperimenterNav(true);
     };
 
@@ -96,6 +114,7 @@ export class Header extends MobxLitElement {
 
     const handleClick = () => {
       this.routerService.navigate(Pages.HOME);
+      this.authService.setEditPermissions(false);
     }
 
     return html`
@@ -111,46 +130,57 @@ export class Header extends MobxLitElement {
   private renderTitle() {
     const activePage = this.routerService.activePage;
 
-    if (activePage === Pages.HOME) {
-      return "Home";
-    } else if (activePage === Pages.SETTINGS
-      || activePage === Pages.PARTICIPANT_SETTINGS) {
-      return "Settings";
-    } else if (activePage === Pages.EXPERIMENT) {
-      return this.experimentService.experiment?.name ?? "Experiment";
-    } else if (activePage === Pages.EXPERIMENT_GROUP) {
-      return "Experiment group: " + this.routerService.activeRoute.params["experiment_group"];  
-    } else if (activePage === Pages.EXPERIMENT_CREATE) {
-      return "New experiment";
-    } else if (activePage === Pages.PARTICIPANT) {
-      return "Welcome, participant!";
-    } else if (activePage === Pages.PARTICIPANT_STAGE) {
-      return this.experimentService.getStageName(
-        this.routerService.activeRoute.params["stage"], true
-      );
+    switch (activePage) {
+      case Pages.HOME:
+        return "Home";
+      case Pages.SETTINGS:
+        return "Settings";
+      case Pages.PARTICIPANT_SETTINGS:
+        return "Settings";
+      case Pages.EXPERIMENT:
+        return this.experimentService.experiment?.name ?? "Experiment";
+      case Pages.EXPERIMENT_GROUP:
+        return "Experiment group: " + this.routerService.activeRoute.params["experiment_group"];
+      case Pages.EXPERIMENT_CREATE:
+        return "New experiment";
+      case Pages.PARTICIPANT:
+        return "Welcome, participant!";
+      case Pages.PARTICIPANT_STAGE:
+        return this.experimentService.getStageName(
+          this.routerService.activeRoute.params["stage"], true
+        );
+      default:
+        return "";
     }
-    return "";
   }
 
   private renderActions() {
     const activePage = this.routerService.activePage;
-    if (activePage === Pages.HOME) {
-      return this.renderCreateExperimentButton();
-    }
-    if (activePage === Pages.PARTICIPANT_STAGE) {
-      const stageName = this.routerService.activeRoute.params["stage"];
-      const currentStage = this.experimentService.getStage(stageName);
-      if (currentStage && currentStage.popupText) {
+
+    switch (activePage) {
+      case Pages.HOME:
         return html`
-          <info-popup .popupText=${currentStage.popupText}></info-popup>
+          ${this.renderCreateExperimentButton()}
+          ${this.renderEditPermissions()}
         `;
-      } else {
+      case Pages.EXPERIMENT_GROUP:
+        return this.renderEditPermissions();
+      case Pages.EXPERIMENT:
+        return this.renderEditPermissions();
+      case Pages.PARTICIPANT_STAGE:
+        const stageName = this.routerService.activeRoute.params["stage"];
+        const currentStage = this.experimentService.getStage(stageName);
+        if (currentStage && currentStage.popupText) {
+          return html`
+            <info-popup .popupText=${currentStage.popupText}></info-popup>
+          `;
+        }
         return nothing;
-      }
-    } else if (activePage === Pages.EXPERIMENT_CREATE) {
-      return this.renderExperimentConfigButtons();
+      case Pages.EXPERIMENT_CREATE:
+        return this.renderExperimentConfigButtons();
+      default:
+        return nothing;
     }
-    return nothing;
   }
 
   private renderCreateExperimentButton() {

--- a/lit/src/components/header/header.ts
+++ b/lit/src/components/header/header.ts
@@ -2,6 +2,7 @@ import "../../pair-components/button";
 import "../../pair-components/icon_button";
 import "../../pair-components/info_popup";
 import "../../pair-components/menu";
+import "../../pair-components/tooltip";
 
 import "../../experiment-components/experiment/experiment_config_menu";
 
@@ -86,20 +87,24 @@ export class Header extends MobxLitElement {
 
     return html`
       <div class="banner">
-        <div>
-          You are previewing as
-          ${participantName ? `${participantName} / ` : 'Participant '}
-          ${this.participantService.profile?.publicId}.
+        <div class="left">
+          <pr-tooltip text="Exit preview" position="BOTTOM_START">
+            <pr-icon-button
+              icon="arrow_back"
+              color="tertiary"
+              padding="small"
+              size="small"
+              variant="default"
+              @click=${handlePreviewOff}
+            >
+            </pr-icon-button>
+          </pr-tooltip>
+          <div>
+            You are previewing as
+            ${participantName ? `${participantName} / ` : 'Participant '}
+            ${this.participantService.profile?.publicId}.
+          </div>
         </div>
-        <pr-button
-          color="tertiary"
-          padding="small"
-          size="small"
-          variant="default"
-          @click=${handlePreviewOff}
-        >
-          Exit preview
-        </pr-button>
       </div>
     `;
   }

--- a/lit/src/components/header/header.ts
+++ b/lit/src/components/header/header.ts
@@ -206,7 +206,7 @@ export class Header extends MobxLitElement {
 
   private renderExperimentConfigTemplateItem(template: ExperimentTemplate) {
     const onClick = () => {
-      this.experimentConfig.loadTemplate(template.id, template.name);
+      this.experimentConfig.loadTemplate(template.id, template);
     };
 
     return html`

--- a/lit/src/components/landing/experiment_card.scss
+++ b/lit/src/components/landing/experiment_card.scss
@@ -40,3 +40,15 @@ p {
   @include typescale.label-medium;
   color: var(--md-sys-color-outline);
 }
+
+.field {
+  @include common.flex-row-align-center;
+  color: var(--md-sys-color-outline);
+  flex-wrap: wrap;
+  gap: common.$spacing-small;
+}
+
+.chip {
+  @include common.chip;
+  cursor: pointer;
+}

--- a/lit/src/components/landing/experiment_card.ts
+++ b/lit/src/components/landing/experiment_card.ts
@@ -78,6 +78,7 @@ export class ExperimentCard extends MobxLitElement {
         ${this.authService.canEdit ? this.renderDeleteButton() : nothing}
       </div>
       <p>${this.experiment.numberOfParticipants} participants</p>
+      ${this.renderGroup()}
       <div class="action-buttons">
         <div class="label">
           <div>${this.experiment.author.displayName}</div>
@@ -107,6 +108,30 @@ export class ExperimentCard extends MobxLitElement {
             style="width: calc(100% * .5 * ${participantProgressRatio()})"
           >
           </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderGroup() {
+    if (!this.experiment || !this.experiment.group) {
+      return nothing;
+    }
+
+    const navigateToGroup = () => {
+      if (this.experiment!.group) {
+        this.routerService.navigate(
+          Pages.EXPERIMENT_GROUP,
+          { "experiment_group": this.experiment!.group }
+        );
+        this.authService.setEditPermissions(false);
+      }
+    };
+
+    return html`
+      <div class="field">Group:
+        <div class="chip secondary" role="button" @click=${navigateToGroup}>
+          ${this.experiment.group}
         </div>
       </div>
     `;

--- a/lit/src/components/landing/experiment_card.ts
+++ b/lit/src/components/landing/experiment_card.ts
@@ -79,6 +79,7 @@ export class ExperimentCard extends MobxLitElement {
       </div>
       <p>${this.experiment.numberOfParticipants} participants</p>
       ${this.renderGroup()}
+      <p class="label">${this.experiment.description}</p>
       <div class="action-buttons">
         <div class="label">
           <div>${this.experiment.author.displayName}</div>

--- a/lit/src/components/landing/experiment_card.ts
+++ b/lit/src/components/landing/experiment_card.ts
@@ -37,11 +37,8 @@ export class ExperimentCard extends MobxLitElement {
         Pages.EXPERIMENT,
         { "experiment": this.experiment!.id }
       );
+      this.authService.setEditPermissions(false);
     }
-
-    const handleDelete = () => {
-      this.experimenterService.deleteExperiment(this.experiment!.id);
-    };
 
     const participantCompletedCount = () => {
       let numCompleted = 0;
@@ -78,14 +75,7 @@ export class ExperimentCard extends MobxLitElement {
           <h3>${this.experiment.name}</h3>
           <div class="label"><small>${this.experiment.id}</small></div>
         </div>
-        <pr-tooltip text="View experiment" position="TOP_END">
-          <pr-icon-button
-            icon="arrow_forward"
-            color="secondary"
-            variant="tonal"
-            @click=${handleClick}>
-          </pr-icon-button>
-        </pr-tooltip>
+        ${this.authService.canEdit ? this.renderDeleteButton() : nothing}
       </div>
       <p>${this.experiment.numberOfParticipants} participants</p>
       <div class="action-buttons">
@@ -93,12 +83,12 @@ export class ExperimentCard extends MobxLitElement {
           <div>${this.experiment.author.displayName}</div>
           <small>${convertUnifiedTimestampToDate(this.experiment.date)}</small>
         </div>
-        <pr-tooltip text="Delete experiment" position="TOP_END">
+        <pr-tooltip text="View experiment" position="TOP_END">
           <pr-icon-button
-            icon="delete"
-            color="error"
+            icon="arrow_forward"
+            color="secondary"
             variant="default"
-            @click=${handleDelete}>
+            @click=${handleClick}>
           </pr-icon-button>
         </pr-tooltip>
       </div>
@@ -119,6 +109,23 @@ export class ExperimentCard extends MobxLitElement {
           </div>
         </div>
       </div>
+    `;
+  }
+
+  private renderDeleteButton() {
+    const handleDelete = () => {
+      this.experimenterService.deleteExperiment(this.experiment!.id);
+    };
+
+    return html`
+      <pr-tooltip text="Delete experiment" position="TOP_END">
+        <pr-icon-button
+          icon="delete"
+          color="error"
+          variant="default"
+          @click=${handleDelete}>
+        </pr-icon-button>
+      </pr-tooltip>
     `;
   }
 }

--- a/lit/src/components/landing/experiment_group.ts
+++ b/lit/src/components/landing/experiment_group.ts
@@ -57,6 +57,10 @@ export class ExperimentGroup extends MobxLitElement {
     `;
   }
   private renderDelete(experiments: Experiment[]) {
+    if (!this.authService.canEdit) {
+      return nothing;
+    }
+
     const onDelete = () => {
       experiments.forEach(experiment => {
         this.experimenterService.deleteExperiment(experiment.id);
@@ -65,13 +69,14 @@ export class ExperimentGroup extends MobxLitElement {
       this.routerService.navigate(
         Pages.HOME,
       );
+      this.authService.setEditPermissions(false);
     };
     return html`
     <pr-tooltip text="Delete group" position="BOTTOM_END">
       <pr-icon-button
         icon="delete"
         color="error"
-        variant="tonal"
+        variant="default"
         @click=${onDelete}
       >
       </pr-icon-button>

--- a/lit/src/components/landing/experiment_landing.ts
+++ b/lit/src/components/landing/experiment_landing.ts
@@ -70,13 +70,8 @@ export class ExperimentLanding extends MobxLitElement {
         Pages.EXPERIMENT_GROUP,
         { "experiment_group": group }
       );
+      this.authService.setEditPermissions(false);
     }
-
-    const handleDelete = () => {
-      experiments.forEach(experiment => {
-        this.experimenterService.deleteExperiment(experiment.id);
-      });
-    };
 
     return html`
       <div class="card">
@@ -86,16 +81,28 @@ export class ExperimentLanding extends MobxLitElement {
           <pr-button color="secondary" variant="tonal" @click=${handleClick}>
             View group
           </pr-button>
-          <pr-tooltip text="Delete experiments in group" position="BOTTOM_END">
-            <pr-icon-button
-              icon="delete"
-              color="error"
-              variant="default"
-              @click=${handleDelete}>
-            </pr-icon-button>
-          </pr-tooltip>
+          ${this.authService.canEdit ? this.renderDeleteGroupButton(experiments) : nothing}
         </div>
       </div>
+    `;
+  }
+
+  private renderDeleteGroupButton(experiments: Experiment[]) {
+    const handleDelete = () => {
+      experiments.forEach(experiment => {
+        this.experimenterService.deleteExperiment(experiment.id);
+      });
+    };
+
+    return html`
+      <pr-tooltip text="Delete experiments in group" position="BOTTOM_END">
+        <pr-icon-button
+          icon="delete"
+          color="error"
+          variant="default"
+          @click=${handleDelete}>
+        </pr-icon-button>
+      </pr-tooltip>
     `;
   }
 
@@ -105,10 +112,6 @@ export class ExperimentLanding extends MobxLitElement {
       this.routerService.navigate(Pages.EXPERIMENT_CREATE);
     }
 
-    const handleDelete = () => {
-      this.experimenterService.deleteTemplate(template.id);
-    };
-
     return html`
       <div class="card">
         <h3>${template.name}</h3>
@@ -117,16 +120,26 @@ export class ExperimentLanding extends MobxLitElement {
           <pr-button variant="default" @click=${handleClick}>
             Use template
           </pr-button>
-          <pr-tooltip text="Delete template" position="BOTTOM_END">
-            <pr-icon-button
-              icon="delete"
-              color="error"
-              variant="default"
-              @click=${handleDelete}>
-            </pr-icon-button>
-          </pr-tooltip>
+          ${this.authService.canEdit ? this.renderDeleteTemplate(template) : nothing}
         </div>
       </div>
+    `;
+  }
+
+  private renderDeleteTemplate(template: ExperimentTemplate) {
+    const handleDelete = () => {
+      this.experimenterService.deleteTemplate(template.id);
+    };
+
+    return html`
+      <pr-tooltip text="Delete template" position="BOTTOM_END">
+        <pr-icon-button
+          icon="delete"
+          color="error"
+          variant="default"
+          @click=${handleDelete}>
+        </pr-icon-button>
+      </pr-tooltip>
     `;
   }
 }

--- a/lit/src/components/landing/experiment_landing.ts
+++ b/lit/src/components/landing/experiment_landing.ts
@@ -108,7 +108,7 @@ export class ExperimentLanding extends MobxLitElement {
 
   private renderTemplateCard(template: ExperimentTemplate) {
     const handleClick = () => {
-      this.experimentConfig.loadTemplate(template.id, template.name);
+      this.experimentConfig.loadTemplate(template.id, template);
       this.routerService.navigate(Pages.EXPERIMENT_CREATE);
     }
 
@@ -116,6 +116,7 @@ export class ExperimentLanding extends MobxLitElement {
       <div class="card">
         <h3>${template.name}</h3>
         <p class="label">ID: ${template.id}</p>
+        <p>${template.description}</p>
         <div class="action-buttons">
           <pr-button variant="default" @click=${handleClick}>
             Use template

--- a/lit/src/components/sidenav/sidenav.ts
+++ b/lit/src/components/sidenav/sidenav.ts
@@ -99,8 +99,7 @@ export class SideNav extends MobxLitElement {
     const navItemClasses = classMap({
       "nav-item": true,
       "primary": true,
-      selected: this.routerService.activePage === Pages.EXPERIMENT
-        && experiment.id === this.experimentService.id,
+      selected: experiment.id === this.experimentService.id,
     });
 
     const handleClick = (_e: Event) => {

--- a/lit/src/experiment-components/experiment/experiment_config.scss
+++ b/lit/src/experiment-components/experiment/experiment_config.scss
@@ -21,10 +21,6 @@ code {
   overflow-wrap: anywhere;
 }
 
-md-checkbox {
-  flex-shrink: 0;
-}
-
 .error {
   color: var(--md-sys-color-error);
 }
@@ -67,17 +63,7 @@ md-checkbox {
 
 .stage-chip {
   @include typescale.label-small;
-  background: var(--md-sys-color-primary-container);
-  border-radius: common.$spacing-small;
-  color: var(--md-sys-color-on-secondary-container);
-  height: max-content;
-  padding: common.$spacing-small common.$spacing-medium;
-  width: max-content;
-
-  &.tertiary {
-    background: var(--md-sys-color-tertiary-container);
-    color: var(--md-sys-color-on-tertiary-container);
-  }
+  @include common.chip;
 }
 
 .stage-description {
@@ -86,30 +72,8 @@ md-checkbox {
   font-style: italic;
 }
 
-.number-input {
-  @include common.number-input;
-}
-
-.checkbox-input {
-  @include common.flex-row-align-center;
-
-  label {
-    @include common.flex-column;
-    gap: common.$spacing-small;
-  }
-}
-
 .subtitle {
   font-style: italic;
-}
-
-.group-container {
-  margin-left: 50px;
-}
-
-.group-container>* {
-  margin-bottom: 8px;
-  /* Spacing between elements. */
 }
 
 .buttons-wrapper {

--- a/lit/src/experiment-components/experiment/experiment_config.scss
+++ b/lit/src/experiment-components/experiment/experiment_config.scss
@@ -21,6 +21,10 @@ code {
   overflow-wrap: anywhere;
 }
 
+md-checkbox {
+  flex-shrink: 0;
+}
+
 .error {
   color: var(--md-sys-color-error);
 }

--- a/lit/src/experiment-components/experiment/experiment_config.scss
+++ b/lit/src/experiment-components/experiment/experiment_config.scss
@@ -116,11 +116,9 @@ md-checkbox {
   @include common.flex-row-align-center;
   gap: common.$spacing-medium;
   justify-content: end;
+}
 
-  &.bottom {
-    border-top: 1px solid var(--md-sys-color-outline-variant);
-    margin-bottom: 0;
-    margin-top: auto;
-    padding-top: common.$spacing-large;
-  }
+experiment-config-actions {
+  margin-bottom: 0;
+  margin-top: auto;
 }

--- a/lit/src/experiment-components/experiment/experiment_config.ts
+++ b/lit/src/experiment-components/experiment/experiment_config.ts
@@ -11,8 +11,7 @@ import "../survey/survey_config";
 import "../tos/tos_config";
 
 import "./experiment_config_actions";
-
-import "@material/web/checkbox/checkbox.js";
+import "./experiment_config_metadata";
 
 import { MobxLitElement } from "@adobe/lit-mobx";
 import { CSSResultGroup, html, nothing } from "lit";
@@ -218,14 +217,14 @@ export class ExperimentConfig extends MobxLitElement {
           <reveal-config></reveal-config>
         `;
       default:
-        return this.renderMetadata();
+        return html`<experiment-config-metadata></experiment-config-metadata>`;
     }
   }
 
   private renderStageInfo(chip: string, content: string) {
     return html`
       <div class="stage-info">
-        <div class="stage-chip">${chip}</div>
+        <div class="stage-chip primary">${chip}</div>
         <div class="stage-description">${content}</div>
       </div>
     `;
@@ -242,128 +241,6 @@ export class ExperimentConfig extends MobxLitElement {
     }
 
     return nothing;
-  }
-
-  private renderMetadata() {
-    const handleName = (e: Event) => {
-      const value = (e.target as HTMLTextAreaElement).value;
-      this.experimentConfig.updateName(value);
-    };
-
-    const handlePublicName = (e: Event) => {
-      const value = (e.target as HTMLTextAreaElement).value;
-      this.experimentConfig.updatePublicName(value);
-    }
-
-    const handleNum = (e: Event) => {
-      const num = Number((e.target as HTMLTextAreaElement).value);
-      this.experimentConfig.updateNumParticipants(num);
-    };
-
-    const handleGroupCheckbox = (e: Event) => {
-      const checked = Boolean((e.target as HTMLInputElement).checked);
-      this.experimentConfig.updateIsExperimentGroup(checked);
-    };
-
-    const handleMultiPartCheckbox = (e: Event) => {
-      const checked = Boolean((e.target as HTMLInputElement).checked);
-      this.experimentConfig.updateIsMultiPart(checked);
-    };
-
-    const handleGroupName = (e: Event) => {
-      const value = (e.target as HTMLTextAreaElement).value;
-      this.experimentConfig.updateGroupName(value);
-    }
-
-    const handleGroupNum = (e: Event) => {
-      const num = Number((e.target as HTMLTextAreaElement).value);
-      this.experimentConfig.updateNumExperiments(num);
-    };
-
-
-    return html`
-      <pr-textarea
-        label="Private experiment name (visible to experimenters)"
-        placeholder="Private experiment name"
-        variant="outlined"
-        .value=${this.experimentConfig.name}
-        .disabled=${this.experimentConfig.isGroup}
-        @input=${handleName}
-      >
-      </pr-textarea>
-      <pr-textarea
-        label="Public experiment name (visible to participants)"
-        placeholder="Public experiment name"
-        variant="outlined"
-        .value=${this.experimentConfig.publicName}
-        @input=${handlePublicName}
-      >
-      </pr-textarea>
-      <div class="number-input">
-        <label for="num">Number of participants</label>
-        <input
-          type="number"
-          id="num"
-          name="numParticipants"
-          min="0"
-          .value=${this.experimentConfig.numParticipants}
-          @input=${handleNum}
-        />
-      </div>
-
-      <div class="checkbox-input-container">
-        <div class="checkbox-input">
-          <md-checkbox id="isExperimentGroup" touch-target="wrapper"
-            .checked=${this.experimentConfig.isGroup}
-            @change=${handleGroupCheckbox}
-          ></md-checkbox>
-          <label for="isExperimentGroup">
-            <div>Create a group of experiments</div>
-            <div class="subtitle">The experiment group options allow you to create a group of experiments with the same configuration.</div>
-          </label>
-        </div>
-      </div>
-
-      ${this.experimentConfig.isGroup
-        ? html`
-              <div class="group-container">
-                <pr-textarea
-                  label="Experiment group name"
-                  placeholder="Prefix of the experiment group"
-                  variant="outlined"
-                  .value=${this.experimentConfig.group}
-                  @input=${handleGroupName}
-                >
-                </pr-textarea>
-                <div class="number-input">
-                    <label for="num">Number of experiments</label>
-                    <input
-                      type="number"
-                      id="numExperiments"
-                      name="numExperiments"
-                      min="1"
-                      .value=${this.experimentConfig.numExperiments}
-                      @input=${handleGroupNum}
-                    />
-                  </div>
-              </div>
-
-                <div class="checkbox-input">
-                  <md-checkbox id="isExperimentGroup" touch-target="wrapper"
-                    .checked=${this.experimentConfig.isMultiPart}
-                    @change=${handleMultiPartCheckbox}
-                  ></md-checkbox>
-                  <label for="isExperimentGroup">
-                    <div>Create a muti-part experiment</div>
-                    <div class="subtitle">
-                        This will add a "lobby" stage; move the stage to divide your experiment into two parts. A lobby experiment will be created for the first part. You can redirect people to the second experiment.
-                    </div>
-                  </label>
-                </div>
-              </div>
-          `
-        : ''}
-    `;
   }
 }
 

--- a/lit/src/experiment-components/experiment/experiment_config.ts
+++ b/lit/src/experiment-components/experiment/experiment_config.ts
@@ -10,6 +10,8 @@ import "../reveal/reveal_config";
 import "../survey/survey_config";
 import "../tos/tos_config";
 
+import "./experiment_config_actions";
+
 import "@material/web/checkbox/checkbox.js";
 
 import { MobxLitElement } from "@adobe/lit-mobx";
@@ -79,9 +81,9 @@ export class ExperimentConfig extends MobxLitElement {
         </div>
       </div>
       ${this.experimentConfig.getExperimentErrors().map(error =>
-      html`<div class="error">Error: ${error}</div>`
-    )}
-      ${this.renderBottomActionButtons()}
+        html`<div class="error">Error: ${error}</div>`
+      )}
+      <experiment-config-actions></experiment-config-actions>
     `;
   }
 
@@ -361,87 +363,6 @@ export class ExperimentConfig extends MobxLitElement {
               </div>
           `
         : ''}
-    `;
-  }
-
-  private renderBottomActionButtons() {
-    const createExperiments = async () => {
-      const experiments = this.experimentConfig.getExperiments() || [];
-      for (let i = 0; i < experiments.length; i++) {
-        const { name, publicName, stages, numberOfParticipants, group } = experiments[i];
-        const experiment = await this.experimenterService.createExperiment(
-          {
-            name,
-            publicName,
-            numberOfParticipants,
-            group,
-          },
-          stages
-        );
-
-        // Navigate if this is the last created experiment.
-        if (i === experiments.length - 1) {
-          if (group) {
-            this.routerService.navigate(
-              Pages.EXPERIMENT_GROUP,
-              { "experiment_group": group }
-            );
-          } else {
-            this.routerService.navigate(
-              Pages.EXPERIMENT,
-              { "experiment": experiment.id }
-            );
-          }
-        }
-      }
-
-      this.experimentConfig.reset();
-    }
-
-    const onCreateExperiment = async () => {
-      const errors = this.experimentConfig.getExperimentErrors();
-      if (errors.length > 0) {
-        console.log(errors);
-        return;
-      }
-      createExperiments();
-    }
-
-    const onCreateTemplate = async () => {
-      const { name, publicName, stages, numberOfParticipants } =
-        this.experimentConfig.getExperiment();
-
-      await this.experimenterService.createTemplate(
-        {
-          name,
-          publicName,
-        }, stages
-      );
-
-      this.experimentConfig.reset();
-    }
-
-    const onClear = () => {
-      this.experimentConfig.reset();
-    }
-
-    const hasErrors = this.experimentConfig.getExperimentErrors().length > 0;
-    const tooltipText = hasErrors ? "Resolve errors to create experiment" : "";
-
-    return html`
-      <div class="buttons-wrapper bottom">
-        <pr-button variant="default" @click=${onClear}>
-          Clear
-        </pr-button>
-        <pr-button variant="tonal" @click=${onCreateTemplate}>
-          Create template
-        </pr-button>
-        <pr-tooltip text=${tooltipText} position="TOP_END">
-          <pr-button @click=${onCreateExperiment}>
-            ${this.experimentConfig.isGroup ? 'Create experiment group' : 'Create experiment'}
-          </pr-button>
-        </pr-tooltip>
-      </div>
     `;
   }
 }

--- a/lit/src/experiment-components/experiment/experiment_config.ts
+++ b/lit/src/experiment-components/experiment/experiment_config.ts
@@ -248,6 +248,11 @@ export class ExperimentConfig extends MobxLitElement {
       this.experimentConfig.updateName(value);
     };
 
+    const handlePublicName = (e: Event) => {
+      const value = (e.target as HTMLTextAreaElement).value;
+      this.experimentConfig.updatePublicName(value);
+    }
+
     const handleNum = (e: Event) => {
       const num = Number((e.target as HTMLTextAreaElement).value);
       this.experimentConfig.updateNumParticipants(num);
@@ -276,12 +281,20 @@ export class ExperimentConfig extends MobxLitElement {
 
     return html`
       <pr-textarea
-        label="Experiment name"
-        placeholder="Name of experiment"
+        label="Private experiment name (visible to experimenters)"
+        placeholder="Private experiment name"
         variant="outlined"
         .value=${this.experimentConfig.name}
         .disabled=${this.experimentConfig.isGroup}
         @input=${handleName}
+      >
+      </pr-textarea>
+      <pr-textarea
+        label="Public experiment name (visible to participants)"
+        placeholder="Public experiment name"
+        variant="outlined"
+        .value=${this.experimentConfig.publicName}
+        @input=${handlePublicName}
       >
       </pr-textarea>
       <div class="number-input">
@@ -355,10 +368,11 @@ export class ExperimentConfig extends MobxLitElement {
     const createExperiments = async () => {
       const experiments = this.experimentConfig.getExperiments() || [];
       for (let i = 0; i < experiments.length; i++) {
-        const { name, stages, numberOfParticipants, group } = experiments[i];
+        const { name, publicName, stages, numberOfParticipants, group } = experiments[i];
         const experiment = await this.experimenterService.createExperiment(
           {
             name,
+            publicName,
             numberOfParticipants,
             group,
           },
@@ -394,12 +408,13 @@ export class ExperimentConfig extends MobxLitElement {
     }
 
     const onCreateTemplate = async () => {
-      const { name, stages, numberOfParticipants } =
+      const { name, publicName, stages, numberOfParticipants } =
         this.experimentConfig.getExperiment();
 
       await this.experimenterService.createTemplate(
         {
-          name
+          name,
+          publicName,
         }, stages
       );
 

--- a/lit/src/experiment-components/experiment/experiment_config_actions.scss
+++ b/lit/src/experiment-components/experiment/experiment_config_actions.scss
@@ -1,0 +1,9 @@
+@use "../../sass/common";
+
+:host {
+  @include common.flex-row-align-center;
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+  gap: common.$spacing-medium;
+  justify-content: end;
+  padding-top: common.$spacing-large;
+}

--- a/lit/src/experiment-components/experiment/experiment_config_actions.ts
+++ b/lit/src/experiment-components/experiment/experiment_config_actions.ts
@@ -1,0 +1,127 @@
+import "../../pair-components/button";
+import "../../pair-components/icon_button";
+import "../../pair-components/tooltip";
+
+import { MobxLitElement } from "@adobe/lit-mobx";
+import { CSSResultGroup, html, nothing } from "lit";
+import { customElement } from "lit/decorators.js";
+
+import { core } from "../../core/core";
+import { ExperimentConfigService } from "../../services/config/experiment_config_service";
+import { AuthService } from "../../services/auth_service";
+import { Pages, RouterService } from "../../services/router_service";
+import { ExperimenterService } from "../../services/experimenter_service";
+
+import { styles } from "./experiment_config_actions.scss";
+
+/** Bottom action buttons for experiment config page*/
+@customElement("experiment-config-actions")
+export class ExperimentConfig extends MobxLitElement {
+  static override styles: CSSResultGroup = [styles];
+
+  private readonly experimentConfig = core.getService(ExperimentConfigService);
+  private readonly authService = core.getService(AuthService);
+  private readonly experimenterService = core.getService(ExperimenterService);
+  private readonly routerService = core.getService(RouterService);
+
+  override render() {
+    if (!this.authService.isExperimenter) {
+      return nothing;
+    }
+
+    const onClear = () => {
+      this.experimentConfig.reset();
+    }
+
+    return html`
+      <pr-button variant="default" @click=${onClear}>
+        Clear
+      </pr-button>
+      ${this.renderCreateTemplateButton()}
+      ${this.renderCreateExperimentButton()}
+    `;
+  }
+
+  private renderCreateTemplateButton() {
+    const onCreateTemplate = async () => {
+      const { name, publicName, stages, numberOfParticipants } =
+        this.experimentConfig.getExperiment();
+
+      await this.experimenterService.createTemplate(
+        {
+          name,
+          publicName,
+        }, stages
+      );
+
+      this.experimentConfig.reset();
+    };
+
+    return html`
+      <pr-button variant="tonal" @click=${onCreateTemplate}>
+        Create template
+      </pr-button>
+    `;
+  }
+
+  private renderCreateExperimentButton() {
+    const createExperiments = async () => {
+      const experiments = this.experimentConfig.getExperiments() || [];
+      for (let i = 0; i < experiments.length; i++) {
+        const { name, publicName, stages, numberOfParticipants, group } = experiments[i];
+        const experiment = await this.experimenterService.createExperiment(
+          {
+            name,
+            publicName,
+            numberOfParticipants,
+            group,
+          },
+          stages
+        );
+
+        // Navigate if this is the last created experiment.
+        if (i === experiments.length - 1) {
+          if (group) {
+            this.routerService.navigate(
+              Pages.EXPERIMENT_GROUP,
+              { "experiment_group": group }
+            );
+          } else {
+            this.routerService.navigate(
+              Pages.EXPERIMENT,
+              { "experiment": experiment.id }
+            );
+          }
+        }
+      }
+
+      this.experimentConfig.reset();
+    };
+
+    const onCreateExperiment = async () => {
+      const errors = this.experimentConfig.getExperimentErrors();
+      if (errors.length > 0) {
+        console.log(errors);
+        return;
+      }
+      createExperiments();
+    };
+
+    const hasErrors = this.experimentConfig.getExperimentErrors().length > 0;
+    const tooltipText = hasErrors ? "Resolve errors to create experiment" : "";
+
+    return html`
+      <pr-tooltip text=${tooltipText} position="TOP_END">
+        <pr-button @click=${onCreateExperiment}>
+          ${this.experimentConfig.isGroup ? 'Create experiment group' : 'Create experiment'}
+        </pr-button>
+      </pr-tooltip>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "experiment-config-actions": ExperimentConfig;
+  }
+}

--- a/lit/src/experiment-components/experiment/experiment_config_actions.ts
+++ b/lit/src/experiment-components/experiment/experiment_config_actions.ts
@@ -44,12 +44,13 @@ export class ExperimentConfig extends MobxLitElement {
 
   private renderCreateTemplateButton() {
     const onCreateTemplate = async () => {
-      const { name, publicName, stages, numberOfParticipants } =
+      const { name, publicName, description, stages, numberOfParticipants } =
         this.experimentConfig.getExperiment();
 
       await this.experimenterService.createTemplate(
         {
           name,
+          description,
           publicName,
         }, stages
       );
@@ -68,11 +69,12 @@ export class ExperimentConfig extends MobxLitElement {
     const createExperiments = async () => {
       const experiments = this.experimentConfig.getExperiments() || [];
       for (let i = 0; i < experiments.length; i++) {
-        const { name, publicName, stages, numberOfParticipants, group } = experiments[i];
+        const { name, publicName, description, stages, numberOfParticipants, group } = experiments[i];
         const experiment = await this.experimenterService.createExperiment(
           {
             name,
             publicName,
+            description,
             numberOfParticipants,
             group,
           },

--- a/lit/src/experiment-components/experiment/experiment_config_metadata.scss
+++ b/lit/src/experiment-components/experiment/experiment_config_metadata.scss
@@ -1,0 +1,34 @@
+@use "../../sass/common";
+@use "../../sass/typescale";
+
+:host {
+  @include common.flex-column;
+  gap: common.$spacing-large;
+}
+
+md-checkbox {
+  flex-shrink: 0;
+}
+
+.number-input {
+  @include common.number-input;
+}
+
+.checkbox-input {
+  @include common.flex-row-align-center;
+
+  label {
+    @include common.flex-column;
+    gap: common.$spacing-small;
+  }
+}
+
+.subtitle {
+  font-style: italic;
+}
+
+.group-container {
+  @include common.flex-column;
+  gap: common.$spacing-large;
+  margin-left: calc(common.$spacing-xxl * 2);
+}

--- a/lit/src/experiment-components/experiment/experiment_config_metadata.scss
+++ b/lit/src/experiment-components/experiment/experiment_config_metadata.scss
@@ -24,11 +24,7 @@ md-checkbox {
 }
 
 .subtitle {
+  @include typescale.label-small;
+  color: var(--md-sys-color-outline);
   font-style: italic;
-}
-
-.group-container {
-  @include common.flex-column;
-  gap: common.$spacing-large;
-  margin-left: calc(common.$spacing-xxl * 2);
 }

--- a/lit/src/experiment-components/experiment/experiment_config_metadata.scss
+++ b/lit/src/experiment-components/experiment/experiment_config_metadata.scss
@@ -6,6 +6,15 @@
   gap: common.$spacing-large;
 }
 
+h2 {
+  @include typescale.title-medium;
+  margin: 0;
+}
+
+.divider {
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+}
+
 md-checkbox {
   flex-shrink: 0;
 }

--- a/lit/src/experiment-components/experiment/experiment_config_metadata.ts
+++ b/lit/src/experiment-components/experiment/experiment_config_metadata.ts
@@ -1,0 +1,162 @@
+import "../../pair-components/button";
+import "../../pair-components/icon_button";
+import "../../pair-components/textarea";
+import "../../pair-components/tooltip";
+
+import "@material/web/checkbox/checkbox.js";
+
+import { MobxLitElement } from "@adobe/lit-mobx";
+import { CSSResultGroup, html, nothing } from "lit";
+import { customElement } from "lit/decorators.js";
+
+import { core } from "../../core/core";
+import { ExperimentConfigService } from "../../services/config/experiment_config_service";
+import { AuthService } from "../../services/auth_service";
+import { Pages, RouterService } from "../../services/router_service";
+
+import { ExperimenterService } from "../../services/experimenter_service";
+import { styles } from "./experiment_config_metadata.scss";
+
+/** Metadata for experiment config page */
+@customElement("experiment-config-metadata")
+export class ExperimentConfig extends MobxLitElement {
+  static override styles: CSSResultGroup = [styles];
+
+  private readonly experimentConfig = core.getService(ExperimentConfigService);
+  private readonly authService = core.getService(AuthService);
+  private readonly experimenterService = core.getService(ExperimenterService);
+  private readonly routerService = core.getService(RouterService);
+
+  override render() {
+    if (!this.authService.isExperimenter) {
+      return nothing;
+    }
+
+    const handleName = (e: Event) => {
+      const value = (e.target as HTMLTextAreaElement).value;
+      this.experimentConfig.updateName(value);
+    };
+
+    const handlePublicName = (e: Event) => {
+      const value = (e.target as HTMLTextAreaElement).value;
+      this.experimentConfig.updatePublicName(value);
+    }
+
+    const handleNum = (e: Event) => {
+      const num = Number((e.target as HTMLTextAreaElement).value);
+      this.experimentConfig.updateNumParticipants(num);
+    };
+
+    const handleGroupCheckbox = (e: Event) => {
+      const checked = Boolean((e.target as HTMLInputElement).checked);
+      this.experimentConfig.updateIsExperimentGroup(checked);
+    };
+
+    return html`
+      <pr-textarea
+        label="Private experiment name (visible to experimenters)"
+        placeholder="Private experiment name"
+        variant="outlined"
+        .value=${this.experimentConfig.name}
+        .disabled=${this.experimentConfig.isGroup}
+        @input=${handleName}
+      >
+      </pr-textarea>
+      <pr-textarea
+        label="Public experiment name (visible to participants)"
+        placeholder="Public experiment name"
+        variant="outlined"
+        .value=${this.experimentConfig.publicName}
+        @input=${handlePublicName}
+      >
+      </pr-textarea>
+      <div class="number-input">
+        <label for="num">Number of participants</label>
+        <input
+          type="number"
+          id="num"
+          name="numParticipants"
+          min="0"
+          .value=${this.experimentConfig.numParticipants}
+          @input=${handleNum}
+        />
+      </div>
+      <div class="checkbox-input-container">
+        <div class="checkbox-input">
+          <md-checkbox id="isExperimentGroup" touch-target="wrapper"
+            .checked=${this.experimentConfig.isGroup}
+            @change=${handleGroupCheckbox}
+          ></md-checkbox>
+          <label for="isExperimentGroup">
+            <div>Create a group of experiments</div>
+            <div class="subtitle">The experiment group options allow you to create a group of experiments with the same configuration.</div>
+          </label>
+        </div>
+      </div>
+      ${this.renderGroupConfig()}
+    `;
+  }
+
+  private renderGroupConfig() {
+    if (!this.experimentConfig.isGroup) {
+      return nothing;
+    }
+
+    const handleGroupName = (e: Event) => {
+      const value = (e.target as HTMLTextAreaElement).value;
+      this.experimentConfig.updateGroupName(value);
+    }
+
+    const handleGroupNum = (e: Event) => {
+      const num = Number((e.target as HTMLTextAreaElement).value);
+      this.experimentConfig.updateNumExperiments(num);
+    };
+
+    const handleMultiPartCheckbox = (e: Event) => {
+      const checked = Boolean((e.target as HTMLInputElement).checked);
+      this.experimentConfig.updateIsMultiPart(checked);
+    };
+
+    return html`
+      <div class="group-container">
+        <pr-textarea
+          label="Experiment group name"
+          placeholder="Prefix of the experiment group"
+          variant="outlined"
+          .value=${this.experimentConfig.group}
+          @input=${handleGroupName}
+        >
+        </pr-textarea>
+        <div class="number-input">
+          <label for="num">Number of experiments</label>
+          <input
+            type="number"
+            id="numExperiments"
+            name="numExperiments"
+            min="1"
+            .value=${this.experimentConfig.numExperiments}
+            @input=${handleGroupNum}
+          />
+        </div>
+        <div class="checkbox-input">
+          <md-checkbox id="isExperimentGroup" touch-target="wrapper"
+            .checked=${this.experimentConfig.isMultiPart}
+            @change=${handleMultiPartCheckbox}
+          ></md-checkbox>
+          <label for="isExperimentGroup">
+            <div>Create a muti-part experiment</div>
+            <div class="subtitle">
+                This will add a "lobby" stage; move the stage to divide your experiment into two parts. A lobby experiment will be created for the first part. You can redirect people to the second experiment.
+            </div>
+          </label>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "experiment-config-metadata": ExperimentConfig;
+  }
+}

--- a/lit/src/experiment-components/experiment/experiment_config_metadata.ts
+++ b/lit/src/experiment-components/experiment/experiment_config_metadata.ts
@@ -32,6 +32,36 @@ export class ExperimentConfig extends MobxLitElement {
       return nothing;
     }
 
+    return html`
+      ${this.renderGroupToggle()}
+      ${this.renderNameFields()}
+      ${this.renderNumParticipantsField()}
+      ${this.renderGroupConfig()}
+    `;
+  }
+
+  private renderNumParticipantsField() {
+    const handleNum = (e: Event) => {
+      const num = Number((e.target as HTMLTextAreaElement).value);
+      this.experimentConfig.updateNumParticipants(num);
+    };
+
+    return html`
+      <div class="number-input">
+        <label for="num">Number of participants</label>
+        <input
+          type="number"
+          id="num"
+          name="numParticipants"
+          min="0"
+          .value=${this.experimentConfig.numParticipants}
+          @input=${handleNum}
+        />
+      </div>
+    `;
+  }
+
+  private renderNameFields() {
     const handleName = (e: Event) => {
       const value = (e.target as HTMLTextAreaElement).value;
       this.experimentConfig.updateName(value);
@@ -40,16 +70,6 @@ export class ExperimentConfig extends MobxLitElement {
     const handlePublicName = (e: Event) => {
       const value = (e.target as HTMLTextAreaElement).value;
       this.experimentConfig.updatePublicName(value);
-    }
-
-    const handleNum = (e: Event) => {
-      const num = Number((e.target as HTMLTextAreaElement).value);
-      this.experimentConfig.updateNumParticipants(num);
-    };
-
-    const handleGroupCheckbox = (e: Event) => {
-      const checked = Boolean((e.target as HTMLInputElement).checked);
-      this.experimentConfig.updateIsExperimentGroup(checked);
     };
 
     const getExperimentNameLabel = () => {
@@ -60,18 +80,6 @@ export class ExperimentConfig extends MobxLitElement {
     }
 
     return html`
-      <div class="checkbox-input-container">
-        <div class="checkbox-input">
-          <md-checkbox id="isExperimentGroup" touch-target="wrapper"
-            .checked=${this.experimentConfig.isGroup}
-            @change=${handleGroupCheckbox}
-          ></md-checkbox>
-          <label for="isExperimentGroup">
-            <div>Create a group of experiments</div>
-            <div class="subtitle">The experiment group options allow you to create a group of experiments with the same configuration.</div>
-          </label>
-        </div>
-      </div>
       <pr-textarea
         label=${getExperimentNameLabel()}
         placeholder=${getExperimentNameLabel()}
@@ -88,18 +96,28 @@ export class ExperimentConfig extends MobxLitElement {
         @input=${handlePublicName}
       >
       </pr-textarea>
-      <div class="number-input">
-        <label for="num">Number of participants</label>
-        <input
-          type="number"
-          id="num"
-          name="numParticipants"
-          min="0"
-          .value=${this.experimentConfig.numParticipants}
-          @input=${handleNum}
-        />
+    `;
+  }
+
+  private renderGroupToggle() {
+    const handleGroupCheckbox = (e: Event) => {
+      const checked = Boolean((e.target as HTMLInputElement).checked);
+      this.experimentConfig.updateIsExperimentGroup(checked);
+    };
+
+    return html`
+      <div class="checkbox-input-container">
+        <div class="checkbox-input">
+          <md-checkbox id="isExperimentGroup" touch-target="wrapper"
+            .checked=${this.experimentConfig.isGroup}
+            @change=${handleGroupCheckbox}
+          ></md-checkbox>
+          <label for="isExperimentGroup">
+            <div>Create a group of experiments</div>
+            <div class="subtitle">The experiment group options allow you to create a group of experiments with the same configuration.</div>
+          </label>
+        </div>
       </div>
-      ${this.renderGroupConfig()}
     `;
   }
 

--- a/lit/src/experiment-components/experiment/experiment_config_metadata.ts
+++ b/lit/src/experiment-components/experiment/experiment_config_metadata.ts
@@ -119,6 +119,8 @@ export class ExperimentConfig extends MobxLitElement {
     };
 
     return html`
+      <div class="divider"></div>
+      <h2>Group-specific settings</h2>
       <div class="number-input">
         <label for="num">Number of experiments</label>
         <input

--- a/lit/src/experiment-components/experiment/experiment_config_metadata.ts
+++ b/lit/src/experiment-components/experiment/experiment_config_metadata.ts
@@ -52,13 +52,31 @@ export class ExperimentConfig extends MobxLitElement {
       this.experimentConfig.updateIsExperimentGroup(checked);
     };
 
+    const getExperimentNameLabel = () => {
+      if (this.experimentConfig.isGroup) {
+        return "Private experiment group prefix";
+      }
+      return "Private experiment name";
+    }
+
     return html`
+      <div class="checkbox-input-container">
+        <div class="checkbox-input">
+          <md-checkbox id="isExperimentGroup" touch-target="wrapper"
+            .checked=${this.experimentConfig.isGroup}
+            @change=${handleGroupCheckbox}
+          ></md-checkbox>
+          <label for="isExperimentGroup">
+            <div>Create a group of experiments</div>
+            <div class="subtitle">The experiment group options allow you to create a group of experiments with the same configuration.</div>
+          </label>
+        </div>
+      </div>
       <pr-textarea
-        label="Private experiment name (visible to experimenters)"
-        placeholder="Private experiment name"
+        label=${getExperimentNameLabel()}
+        placeholder=${getExperimentNameLabel()}
         variant="outlined"
         .value=${this.experimentConfig.name}
-        .disabled=${this.experimentConfig.isGroup}
         @input=${handleName}
       >
       </pr-textarea>
@@ -81,18 +99,6 @@ export class ExperimentConfig extends MobxLitElement {
           @input=${handleNum}
         />
       </div>
-      <div class="checkbox-input-container">
-        <div class="checkbox-input">
-          <md-checkbox id="isExperimentGroup" touch-target="wrapper"
-            .checked=${this.experimentConfig.isGroup}
-            @change=${handleGroupCheckbox}
-          ></md-checkbox>
-          <label for="isExperimentGroup">
-            <div>Create a group of experiments</div>
-            <div class="subtitle">The experiment group options allow you to create a group of experiments with the same configuration.</div>
-          </label>
-        </div>
-      </div>
       ${this.renderGroupConfig()}
     `;
   }
@@ -100,11 +106,6 @@ export class ExperimentConfig extends MobxLitElement {
   private renderGroupConfig() {
     if (!this.experimentConfig.isGroup) {
       return nothing;
-    }
-
-    const handleGroupName = (e: Event) => {
-      const value = (e.target as HTMLTextAreaElement).value;
-      this.experimentConfig.updateGroupName(value);
     }
 
     const handleGroupNum = (e: Event) => {
@@ -118,38 +119,28 @@ export class ExperimentConfig extends MobxLitElement {
     };
 
     return html`
-      <div class="group-container">
-        <pr-textarea
-          label="Experiment group name"
-          placeholder="Prefix of the experiment group"
-          variant="outlined"
-          .value=${this.experimentConfig.group}
-          @input=${handleGroupName}
-        >
-        </pr-textarea>
-        <div class="number-input">
-          <label for="num">Number of experiments</label>
-          <input
-            type="number"
-            id="numExperiments"
-            name="numExperiments"
-            min="1"
-            .value=${this.experimentConfig.numExperiments}
-            @input=${handleGroupNum}
-          />
-        </div>
-        <div class="checkbox-input">
-          <md-checkbox id="isExperimentGroup" touch-target="wrapper"
-            .checked=${this.experimentConfig.isMultiPart}
-            @change=${handleMultiPartCheckbox}
-          ></md-checkbox>
-          <label for="isExperimentGroup">
-            <div>Create a muti-part experiment</div>
-            <div class="subtitle">
-                This will add a "lobby" stage; move the stage to divide your experiment into two parts. A lobby experiment will be created for the first part. You can redirect people to the second experiment.
-            </div>
-          </label>
-        </div>
+      <div class="number-input">
+        <label for="num">Number of experiments</label>
+        <input
+          type="number"
+          id="numExperiments"
+          name="numExperiments"
+          min="1"
+          .value=${this.experimentConfig.numExperiments}
+          @input=${handleGroupNum}
+        />
+      </div>
+      <div class="checkbox-input">
+        <md-checkbox id="isExperimentGroup" touch-target="wrapper"
+          .checked=${this.experimentConfig.isMultiPart}
+          @change=${handleMultiPartCheckbox}
+        ></md-checkbox>
+        <label for="isExperimentGroup">
+          <div>Create a muti-part experiment</div>
+          <div class="subtitle">
+            This will add a "lobby" stage; move the stage to divide your experiment into two parts. A lobby experiment will be created for the first part. You can redirect people to the second experiment.
+          </div>
+        </label>
       </div>
     `;
   }

--- a/lit/src/experiment-components/experiment/experiment_config_metadata.ts
+++ b/lit/src/experiment-components/experiment/experiment_config_metadata.ts
@@ -35,8 +35,27 @@ export class ExperimentConfig extends MobxLitElement {
     return html`
       ${this.renderGroupToggle()}
       ${this.renderNameFields()}
+      ${this.renderDescriptionField()}
       ${this.renderNumParticipantsField()}
       ${this.renderGroupConfig()}
+    `;
+  }
+
+  private renderDescriptionField() {
+    const handleDescription = (e: Event) => {
+      const value = (e.target as HTMLTextAreaElement).value;
+      this.experimentConfig.updateDescription(value);
+    }
+
+    return html`
+      <pr-textarea
+        label="Private experiment description"
+        placeholder="This description is only visible to experimenters"
+        variant="outlined"
+        .value=${this.experimentConfig.description}
+        @input=${handleDescription}
+      >
+      </pr-textarea>
     `;
   }
 
@@ -81,19 +100,19 @@ export class ExperimentConfig extends MobxLitElement {
 
     return html`
       <pr-textarea
-        label=${getExperimentNameLabel()}
-        placeholder=${getExperimentNameLabel()}
-        variant="outlined"
-        .value=${this.experimentConfig.name}
-        @input=${handleName}
-      >
-      </pr-textarea>
-      <pr-textarea
         label="Public experiment name (visible to participants)"
         placeholder="Public experiment name"
         variant="outlined"
         .value=${this.experimentConfig.publicName}
         @input=${handlePublicName}
+      >
+      </pr-textarea>
+      <pr-textarea
+        label=${getExperimentNameLabel()}
+        placeholder=${getExperimentNameLabel()}
+        variant="outlined"
+        .value=${this.experimentConfig.name}
+        @input=${handleName}
       >
       </pr-textarea>
     `;

--- a/lit/src/experiment-components/experiment/experiment_config_sidenav.scss
+++ b/lit/src/experiment-components/experiment/experiment_config_sidenav.scss
@@ -22,15 +22,23 @@
   }
 
   .label {
-    max-width: 200px;
+    @include common.flex-row-align-center;
+    flex-wrap: wrap;
+    gap: common.$spacing-small;
   }
 
   .buttons {
     @include common.flex-row-align-center;
+    flex-shrink: 0;
     gap: common.$spacing-small;
   }
 }
 
 .icon-wrapper {
   width: common.$spacing-xxl;
+}
+
+.chip {
+  @include typescale.label-small;
+  @include common.chip;
 }

--- a/lit/src/experiment-components/experiment/experiment_config_sidenav.ts
+++ b/lit/src/experiment-components/experiment/experiment_config_sidenav.ts
@@ -92,7 +92,9 @@ export class ExperimentConfigSidenav extends MobxLitElement {
     return html`
       <div class=${classes} role="button" @click=${handleClick}>
         <div class="label">
-          ${index + 1}. ${stage.name}
+          <div>${index + 1}. ${stage.name}</div>
+          ${this.experimentConfig.dividerStageId === stage.id ?
+            html`<div class="chip tertiary">lobby stage</div>` : nothing}
         </div>
         <div class="buttons">
           <pr-icon-button

--- a/lit/src/experiment-components/experiment/experiment_preview.scss
+++ b/lit/src/experiment-components/experiment/experiment_preview.scss
@@ -18,7 +18,11 @@ h2 {
   gap: common.$spacing-medium;
   justify-content: space-between;
 
-  .left,
+  .left {
+    @include common.flex-column;
+    gap: common.$spacing-medium;
+  }
+
   .right {
     @include common.flex-row-align-center;
     gap: common.$spacing-medium;
@@ -26,8 +30,20 @@ h2 {
 }
 
 .stat {
+  @include common.flex-row-align-center;
   @include typescale.body-medium;
   color: var(--md-sys-color-outline);
+  flex-wrap: wrap;
+  gap: common.$spacing-small;
+
+  &.small {
+    @include typescale.body-small;
+  }
+}
+
+.chip {
+  @include common.chip;
+  cursor: pointer;
 }
 
 .profile-wrapper {

--- a/lit/src/experiment-components/experiment/experiment_preview.ts
+++ b/lit/src/experiment-components/experiment/experiment_preview.ts
@@ -44,6 +44,9 @@ export class ExperimentPreview extends MobxLitElement {
             ${this.experimentService.experiment?.numberOfParticipants}
             participants
           </div>
+          <div class="stat small">
+            Public name: ${this.experimentService.experiment?.publicName}
+          </div>
           ${this.renderGroup()}
         </div>
         <div class="right">

--- a/lit/src/experiment-components/experiment/experiment_preview.ts
+++ b/lit/src/experiment-components/experiment/experiment_preview.ts
@@ -39,9 +39,12 @@ export class ExperimentPreview extends MobxLitElement {
 
     return html`
       <div class="top-bar">
-        <div class="stat">
-          ${this.experimentService.experiment?.numberOfParticipants}
-          participants
+        <div class="left">
+          <div class="stat">
+            ${this.experimentService.experiment?.numberOfParticipants}
+            participants
+          </div>
+          ${this.renderGroup()}
         </div>
         <div class="right">
           ${this.renderFork()}
@@ -60,6 +63,31 @@ export class ExperimentPreview extends MobxLitElement {
       <div class="profile-wrapper">
         ${this.experimentService.privateParticipants.map(participant =>
           html`<profile-preview .profile=${participant}></profile-preview>`)}
+      </div>
+    `;
+  }
+
+  private renderGroup() {
+    if (!this.experimentService.experiment || !this.experimentService.experiment.group) {
+      return nothing;
+    }
+
+    const navigateToGroup = () => {
+      if (this.experimentService.experiment!.group) {
+        this.routerService.navigate(
+          Pages.EXPERIMENT_GROUP,
+          { "experiment_group": this.experimentService.experiment!.group }
+        );
+        this.authService.setEditPermissions(false);
+      }
+    };
+
+    return html`
+      <div class="stat small">
+        <div>Group:</div>
+        <div class="chip" role="button" @click=${navigateToGroup}>
+          ${this.experimentService.experiment.group}
+        </div>
       </div>
     `;
   }

--- a/lit/src/experiment-components/experiment/experiment_preview.ts
+++ b/lit/src/experiment-components/experiment/experiment_preview.ts
@@ -5,7 +5,7 @@ import "../../pair-components/tooltip";
 import "../profile/profile_preview";
 
 import { MobxLitElement } from "@adobe/lit-mobx";
-import { CSSResultGroup, html } from "lit";
+import { CSSResultGroup, html, nothing } from "lit";
 import { customElement } from "lit/decorators.js";
 
 import { core } from "../../core/core";
@@ -65,9 +65,14 @@ export class ExperimentPreview extends MobxLitElement {
   }
 
   private renderDelete() {
+    if (!this.authService.canEdit) {
+      return nothing;
+    }
+
     const onDelete = () => {
       this.experimenterService.deleteExperiment(this.experimentService.id!);
       this.routerService.navigate(Pages.HOME);
+      this.authService.setEditPermissions(false);
     };
 
     return html`
@@ -75,7 +80,7 @@ export class ExperimentPreview extends MobxLitElement {
         <pr-icon-button
           icon="delete"
           color="error"
-          variant="tonal"
+          variant="default"
           @click=${onDelete}
         >
         </pr-icon-button>

--- a/lit/src/experiment-components/experiment/experiment_preview.ts
+++ b/lit/src/experiment-components/experiment/experiment_preview.ts
@@ -56,6 +56,9 @@ export class ExperimentPreview extends MobxLitElement {
         </div>
       </div>
       <div class="row">
+        ${this.experimentService.experiment?.description}
+      </div>
+      <div class="row">
         <pr-button
           color="tertiary"
           variant="tonal"

--- a/lit/src/experiment-components/sidenav/sidenav.ts
+++ b/lit/src/experiment-components/sidenav/sidenav.ts
@@ -103,7 +103,7 @@ export class SideNav extends MobxLitElement {
           class=${navItemClasses}
           role="button"
           @click=${handleClick}>
-          ${experiment.name}
+          ${experiment.publicName}
         </div>
       </div>
     `;

--- a/lit/src/sass/_common.scss
+++ b/lit/src/sass/_common.scss
@@ -86,6 +86,7 @@
   background: var(--md-sys-color-surface-container);
   border-radius: $spacing-medium;
   color: var(--md-sys-color-on-surface);
+  height: max-content;
   padding: $spacing-xs $spacing-small;
 
   &.primary {

--- a/lit/src/sass/_common.scss
+++ b/lit/src/sass/_common.scss
@@ -82,6 +82,29 @@
   }
 }
 
+@mixin chip {
+  background: var(--md-sys-color-surface-container);
+  border-radius: $spacing-medium;
+  color: var(--md-sys-color-on-surface);
+  padding: $spacing-xs $spacing-small;
+
+  &.primary {
+    background: var(--md-sys-color-primary-container);
+    color: var(--md-sys-color-on-primary-container);
+  }
+
+
+  &.secondary {
+    background: var(--md-sys-color-secondary-container);
+    color: var(--md-sys-color-on-secondary-container);
+  }
+
+  &.tertiary {
+    background: var(--md-sys-color-tertiary-container);
+    color: var(--md-sys-color-on-tertiary-container);
+  }
+}
+
 @mixin info-card {
   @include flex-column;
   background: var(--md-sys-color-surface);

--- a/lit/src/services/auth_service.ts
+++ b/lit/src/services/auth_service.ts
@@ -46,6 +46,7 @@ export class AuthService extends Service {
 
   @observable user: User|null|undefined = undefined;
   @observable isExperimenter: boolean|null = null;
+  @observable canEdit = false;
 
   @computed get userId() {
     return this.user?.uid;
@@ -57,6 +58,10 @@ export class AuthService extends Service {
 
   @computed get authenticated() {
     return this.initialAuthCheck && this.user !== null;
+  }
+
+  setEditPermissions(canEdit: boolean) {
+    this.canEdit = !this.isExperimenter ? false : canEdit;
   }
 
   signInWithGoogle() {

--- a/lit/src/services/config/experiment_config_service.ts
+++ b/lit/src/services/config/experiment_config_service.ts
@@ -24,13 +24,12 @@ export class ExperimentConfigService extends Service {
     makeObservable(this);
   }
 
-  @observable name = 'Untitled experiment';
+  @observable name = 'Untitled';
   @observable publicName = 'Experiment';
   @observable numParticipants = 3;
 
   // Experiment group parameters.
   @observable isGroup = false;
-  @observable group = "";
   @observable numExperiments = 1;
 
   @observable isMultiPart = false;
@@ -59,9 +58,9 @@ export class ExperimentConfigService extends Service {
     const experiments = [];
     for (let i = 0; i < numExperiments; i++) {
       experiments.push({
-        name: toJS(this.group + '_' + randstr(6)),
+        name: toJS(this.name + '_' + randstr(6)),
         publicName: toJS(this.publicName),
-        group: toJS(this.group),
+        group: toJS(this.name),
         stages: convertExperimentStages(toJS(stages)),
         numberOfParticipants: toJS(this.numParticipants),
       });
@@ -93,9 +92,9 @@ export class ExperimentConfigService extends Service {
       const experiments = [];
       // Create one lobby.
       experiments.push({
-        name: toJS(this.group + '_lobby'),
+        name: toJS(this.name + '_lobby'),
         publicName: toJS(this.publicName),
-        group: toJS(this.group),
+        group: toJS(this.name),
         stages: convertExperimentStages(toJS(preStages)),
         numberOfParticipants: toJS(this.numParticipants),
       });
@@ -115,9 +114,9 @@ export class ExperimentConfigService extends Service {
 
     if (this.isGroup) {
       return {
-        name: toJS(this.group + '_' + randstr(6)),
+        name: toJS(this.name + '_' + randstr(6)),
         publicName: toJS(this.publicName),
-        group: toJS(this.group),
+        group: toJS(this.name),
         stages: convertExperimentStages(toJS(this.stages)),
         numberOfParticipants: toJS(this.numParticipants),
       };
@@ -135,12 +134,12 @@ export class ExperimentConfigService extends Service {
     const errors: string[] = validateStageConfigs(this.stages);
 
     if (this.isGroup) {
-      if (this.group.length === 0) {
+      if (this.name.length === 0) {
         errors.push("Experiment group name cannot be empty");
       }
 
       const alphanumRegex = /[^a-zA-Z0-9_-]/;
-      if (alphanumRegex.test(this.group)) {
+      if (alphanumRegex.test(this.name)) {
         errors.push("Only alphanumeric characters, underscores (_), and hyphens (-) are allowed.");
       }
     } else {
@@ -221,11 +220,6 @@ export class ExperimentConfigService extends Service {
     }
   }
 
-
-  updateGroupName(name: string) {
-    this.group = name;
-  }
-
   updateNumExperiments(num: number) {
     this.numExperiments = num;
   }
@@ -286,13 +280,12 @@ export class ExperimentConfigService extends Service {
   }
 
   reset() {
-    this.name = 'Untitled experiment';
+    this.name = 'Untitled';
     this.publicName = 'Experiment';
     this.numParticipants = 3;
     this.stages = [createTOSStage(), createProfileStage()];
     this.currentStageIndex = -1;
     this.isGroup = false;
     this.isMultiPart = false;
-    this.group = '';
   }
 }

--- a/lit/src/services/config/experiment_config_service.ts
+++ b/lit/src/services/config/experiment_config_service.ts
@@ -33,7 +33,7 @@ export class ExperimentConfigService extends Service {
   @observable numExperiments = 1;
 
   @observable isMultiPart = false;
-  private dividerStageId = "";
+  @observable dividerStageId = "";
 
   @observable stages: StageConfig[] = [createTOSStage(), createProfileStage()];
   @observable currentStageIndex = -1;
@@ -105,8 +105,6 @@ export class ExperimentConfigService extends Service {
     }
 
   }
-
-
 
   // Converts and returns data required for experiment creation
   // (note that this adjusts some stage data, e.g., adds numbering to stages)

--- a/lit/src/services/config/experiment_config_service.ts
+++ b/lit/src/services/config/experiment_config_service.ts
@@ -24,7 +24,8 @@ export class ExperimentConfigService extends Service {
     makeObservable(this);
   }
 
-  @observable name = 'New experiment';
+  @observable name = 'Untitled experiment';
+  @observable publicName = 'Experiment';
   @observable numParticipants = 3;
 
   // Experiment group parameters.
@@ -59,6 +60,7 @@ export class ExperimentConfigService extends Service {
     for (let i = 0; i < numExperiments; i++) {
       experiments.push({
         name: toJS(this.group + '_' + randstr(6)),
+        publicName: toJS(this.publicName),
         group: toJS(this.group),
         stages: convertExperimentStages(toJS(stages)),
         numberOfParticipants: toJS(this.numParticipants),
@@ -73,6 +75,7 @@ export class ExperimentConfigService extends Service {
       return [
         {
           name: toJS(this.name),
+          publicName: toJS(this.publicName),
           group: toJS(''),
           stages: toJS(this.stages),
           numberOfParticipants: toJS(this.numParticipants),
@@ -91,6 +94,7 @@ export class ExperimentConfigService extends Service {
       // Create one lobby.
       experiments.push({
         name: toJS(this.group + '_lobby'),
+        publicName: toJS(this.publicName),
         group: toJS(this.group),
         stages: convertExperimentStages(toJS(preStages)),
         numberOfParticipants: toJS(this.numParticipants),
@@ -112,6 +116,7 @@ export class ExperimentConfigService extends Service {
     if (this.isGroup) {
       return {
         name: toJS(this.group + '_' + randstr(6)),
+        publicName: toJS(this.publicName),
         group: toJS(this.group),
         stages: convertExperimentStages(toJS(this.stages)),
         numberOfParticipants: toJS(this.numParticipants),
@@ -119,6 +124,7 @@ export class ExperimentConfigService extends Service {
     }
     return {
       name: toJS(this.name),
+      publicName: toJS(this.publicName),
       group: toJS(''),
       stages: toJS(this.stages),
       numberOfParticipants: toJS(this.numParticipants),
@@ -180,9 +186,14 @@ export class ExperimentConfigService extends Service {
     return this.stages[this.currentStageIndex];
   }
 
-  // Update experiment name
+  // Update private experiment name
   updateName(name: string) {
     this.name = name;
+  }
+
+  // Update public experiment name
+  updatePublicName(name: string) {
+    this.publicName = name;
   }
 
   updateNumParticipants(num: number) {
@@ -275,7 +286,8 @@ export class ExperimentConfigService extends Service {
   }
 
   reset() {
-    this.name = 'New experiment';
+    this.name = 'Untitled experiment';
+    this.publicName = 'Experiment';
     this.numParticipants = 3;
     this.stages = [createTOSStage(), createProfileStage()];
     this.currentStageIndex = -1;

--- a/lit/src/services/config/experiment_config_service.ts
+++ b/lit/src/services/config/experiment_config_service.ts
@@ -4,7 +4,7 @@ import { computed, makeObservable, observable, toJS } from "mobx";
 import { FirebaseService } from "../firebase_service";
 import { Service } from "../service";
 
-import { randstr, StageConfig, StageKind, validateStageConfigs } from "@llm-mediation-experiments/utils";
+import { ExperimentTemplate, randstr, StageConfig, StageKind, validateStageConfigs } from "@llm-mediation-experiments/utils";
 import {
   collectSnapshotWithId,
   convertExperimentStages,
@@ -26,6 +26,7 @@ export class ExperimentConfigService extends Service {
 
   @observable name = 'Untitled';
   @observable publicName = 'Experiment';
+  @observable description = '';
   @observable numParticipants = 3;
 
   // Experiment group parameters.
@@ -39,7 +40,7 @@ export class ExperimentConfigService extends Service {
   @observable currentStageIndex = -1;
 
   // Loads template as current config
-  loadTemplate(templateId: string, name = "New experiment") {
+  loadTemplate(templateId: string, template: Partial<ExperimentTemplate>) {
     const templateCollection = collection(
       this.sp.firebaseService.firestore,
       'templates',
@@ -50,7 +51,9 @@ export class ExperimentConfigService extends Service {
     getDocs(templateCollection).then(stagesDocs => {
       const stages = (collectSnapshotWithId(stagesDocs, 'name') as StageConfig[]);
       this.stages = stages;
-      this.name = name;
+      this.name = template.name ?? 'Untitled';
+      this.publicName = template.publicName ?? 'Experiment';
+      this.description = template.description ?? '';
     });
   }
 
@@ -60,6 +63,7 @@ export class ExperimentConfigService extends Service {
       experiments.push({
         name: toJS(this.name + '_' + randstr(6)),
         publicName: toJS(this.publicName),
+        description: toJS(this.description),
         group: toJS(this.name),
         stages: convertExperimentStages(toJS(stages)),
         numberOfParticipants: toJS(this.numParticipants),
@@ -75,6 +79,7 @@ export class ExperimentConfigService extends Service {
         {
           name: toJS(this.name),
           publicName: toJS(this.publicName),
+          description: toJS(this.description),
           group: toJS(''),
           stages: toJS(this.stages),
           numberOfParticipants: toJS(this.numParticipants),
@@ -94,6 +99,7 @@ export class ExperimentConfigService extends Service {
       experiments.push({
         name: toJS(this.name + '_lobby'),
         publicName: toJS(this.publicName),
+        description: toJS(this.description),
         group: toJS(this.name),
         stages: convertExperimentStages(toJS(preStages)),
         numberOfParticipants: toJS(this.numParticipants),
@@ -114,6 +120,7 @@ export class ExperimentConfigService extends Service {
       return {
         name: toJS(this.name + '_' + randstr(6)),
         publicName: toJS(this.publicName),
+        description: toJS(this.description),
         group: toJS(this.name),
         stages: convertExperimentStages(toJS(this.stages)),
         numberOfParticipants: toJS(this.numParticipants),
@@ -122,6 +129,7 @@ export class ExperimentConfigService extends Service {
     return {
       name: toJS(this.name),
       publicName: toJS(this.publicName),
+      description: toJS(this.description),
       group: toJS(''),
       stages: toJS(this.stages),
       numberOfParticipants: toJS(this.numParticipants),
@@ -222,6 +230,10 @@ export class ExperimentConfigService extends Service {
     this.numExperiments = num;
   }
 
+  updateDescription(description: string) {
+    this.description = description;
+  }
+
   updateStages(stages: StageConfig[]) {
     this.stages = stages;
   }
@@ -280,6 +292,7 @@ export class ExperimentConfigService extends Service {
   reset() {
     this.name = 'Untitled';
     this.publicName = 'Experiment';
+    this.description = '';
     this.numParticipants = 3;
     this.stages = [createTOSStage(), createProfileStage()];
     this.currentStageIndex = -1;


### PR DESCRIPTION
- Enable experimenters to set public name, description for experiments
- Refactor metadata config UI
- Only show "delete experiment" buttons when experimenters click to "edit"
- Fix small UX bugs (e.g., flex-shrink, chip height)
- Add small visual cues to frontend (e.g., indicator for lobby stage, experiment selection in sidenav)