### PR TITLE
Add discussed changes to lobby transfer implementation

### DIFF
--- a/functions/src/endpoints/experiments.endpoints.ts
+++ b/functions/src/endpoints/experiments.endpoints.ts
@@ -241,7 +241,7 @@ export const createParticipant = onCall(async (request) => {
     const participantRef = experimentRef.collection('participants').doc();
     const participantData: ParticipantProfile = {
       publicId: participantPublicId(experimentData.numberOfParticipants),
-      currentStageId: data.participantData?.currentStageId ?? currentStageId,
+      currentStageId: currentStageId,
       pronouns: data.participantData?.pronouns ?? null,
       name: data.participantData?.name ?? null,
       avatarUrl: data.participantData?.avatarUrl ?? null,

--- a/functions/src/endpoints/experiments.endpoints.ts
+++ b/functions/src/endpoints/experiments.endpoints.ts
@@ -1,4 +1,6 @@
-/** Endpoints for interactions with experiments */
+/** Endpoints for interactions with experiments, including
+  * creating/deleting experiments and participants.
+  */
 
 import {
   ChatAnswer,

--- a/functions/src/endpoints/experiments.endpoints.ts
+++ b/functions/src/endpoints/experiments.endpoints.ts
@@ -237,11 +237,11 @@ export const createParticipant = onCall(async (request) => {
     const participantRef = experimentRef.collection('participants').doc();
     const participantData: ParticipantProfile = {
       publicId: participantPublicId(experimentData.numberOfParticipants),
-      currentStageId: data.participantData!.currentStageId || null,
-      pronouns: data.participantData!.pronouns || null,
-      name: data.participantData!.name || null,
-      avatarUrl: data.participantData!.avatarUrl || null,
-      acceptTosTimestamp: data.participantData!.acceptTosTimestamp || null,
+      currentStageId: data.participantData?.currentStageId ?? currentStageId,
+      pronouns: data.participantData?.pronouns ?? null,
+      name: data.participantData?.name ?? null,
+      avatarUrl: data.participantData?.avatarUrl ?? null,
+      acceptTosTimestamp: data.participantData?.acceptTosTimestamp ?? null,
       completedExperiment: null
     };
 

--- a/functions/src/endpoints/experiments.endpoints.ts
+++ b/functions/src/endpoints/experiments.endpoints.ts
@@ -48,7 +48,7 @@ export const createExperiment = onCall(async (request) => {
 
     await app.firestore().runTransaction(async (transaction) => {
       let { numberOfParticipants } = data.metadata;
-      const { name, publicName, description, tags, group } = data.metadata;
+      const { name, publicName, description, tags, isLobby, group } = data.metadata;
 
       numberOfParticipants = numberOfParticipants ?? DEFAULT_PARTICIPANT_COUNT;
 
@@ -60,6 +60,7 @@ export const createExperiment = onCall(async (request) => {
         tags,
         author: { uid: request.auth?.uid, displayName: request.auth?.token?.name ?? '' },
         starred: {},
+        isLobby,
         ...(data.type === 'experiments'
           ? {
             date: Timestamp.now(),

--- a/functions/src/endpoints/experiments.endpoints.ts
+++ b/functions/src/endpoints/experiments.endpoints.ts
@@ -142,6 +142,7 @@ export const createExperiment = onCall(async (request) => {
           avatarUrl: null,
           acceptTosTimestamp: null,
           completedExperiment: null,
+          transferConfig: null,
         };
 
         // Create the participant document
@@ -245,7 +246,8 @@ export const createParticipant = onCall(async (request) => {
       name: data.participantData?.name ?? null,
       avatarUrl: data.participantData?.avatarUrl ?? null,
       acceptTosTimestamp: data.participantData?.acceptTosTimestamp ?? null,
-      completedExperiment: null
+      completedExperiment: null,
+      transferConfig: null,
     };
 
     // Increment the number of participants in the experiment metadata

--- a/functions/src/endpoints/participants.endpoints.ts
+++ b/functions/src/endpoints/participants.endpoints.ts
@@ -1,4 +1,4 @@
-/** Endpoints for interactions with participants */
+/** Endpoints for participanting in experiments */
 
 import {
   QuestionAnswer,

--- a/lit/src/experiment-components/experiment/experiment_config_actions.ts
+++ b/lit/src/experiment-components/experiment/experiment_config_actions.ts
@@ -44,17 +44,7 @@ export class ExperimentConfig extends MobxLitElement {
 
   private renderCreateTemplateButton() {
     const onCreateTemplate = async () => {
-      const { name, publicName, description, stages, numberOfParticipants } =
-        this.experimentConfig.getExperiment();
-
-      await this.experimenterService.createTemplate(
-        {
-          name,
-          description,
-          publicName,
-        }, stages
-      );
-
+      this.experimentConfig.createTemplate();
       this.experimentConfig.reset();
     };
 
@@ -67,36 +57,7 @@ export class ExperimentConfig extends MobxLitElement {
 
   private renderCreateExperimentButton() {
     const createExperiments = async () => {
-      const experiments = this.experimentConfig.getExperiments() || [];
-      for (let i = 0; i < experiments.length; i++) {
-        const { name, publicName, description, stages, numberOfParticipants, group } = experiments[i];
-        const experiment = await this.experimenterService.createExperiment(
-          {
-            name,
-            publicName,
-            description,
-            numberOfParticipants,
-            group,
-          },
-          stages
-        );
-
-        // Navigate if this is the last created experiment.
-        if (i === experiments.length - 1) {
-          if (group) {
-            this.routerService.navigate(
-              Pages.EXPERIMENT_GROUP,
-              { "experiment_group": group }
-            );
-          } else {
-            this.routerService.navigate(
-              Pages.EXPERIMENT,
-              { "experiment": experiment.id }
-            );
-          }
-        }
-      }
-
+      this.experimentConfig.createExperiments();
       this.experimentConfig.reset();
     };
 

--- a/lit/src/experiment-components/experiment/experiment_preview.ts
+++ b/lit/src/experiment-components/experiment/experiment_preview.ts
@@ -77,6 +77,13 @@ export class ExperimentPreview extends MobxLitElement {
     };
 
     const group = this.experimentService.experiment?.group!;
+    const participants = this.experimentService.privateParticipants;
+    const currentParticipants = participants.filter(
+      participant => !participant.transferConfig
+    );
+    const transferredParticipants = participants.filter(
+      participant => participant.transferConfig
+    );
 
     return html`
       <div class="top-bar">
@@ -109,9 +116,24 @@ export class ExperimentPreview extends MobxLitElement {
           Add participant
         </pr-button>
       </div>
+
+      <h2>${currentParticipants.length} current participants</h2>
       <div class="profile-wrapper">
-        ${this.experimentService.privateParticipants.map(participant =>
-      html`<profile-preview .profile=${participant} .availableTransferExperiments=${getTransferableExperiments()}></profile-preview>`)}
+        ${currentParticipants.map(participant =>
+        html`
+          <profile-preview
+            .profile=${participant}
+            .availableTransferExperiments=${getTransferableExperiments()}>
+          </profile-preview>
+        `)}
+      </div>
+
+      <h2>${transferredParticipants.length} transferred participants</h2>
+      <div class="profile-wrapper">
+        ${transferredParticipants.map(participant =>
+        html`
+          <profile-preview .profile=${participant}></profile-preview>
+        `)}
       </div>
     `;
   }

--- a/lit/src/experiment-components/experiment/experiment_preview.ts
+++ b/lit/src/experiment-components/experiment/experiment_preview.ts
@@ -41,34 +41,12 @@ export class ExperimentPreview extends MobxLitElement {
   }
 
   override render() {
-    const addParticipant = async () => {
-      try {
-        const response = await this.experimenterService.createParticipant(this.experimentService.id!);
-        return response.participant;
-      } catch (error) {
-        console.error('Error creating participant:', error);
-        throw error;
-      }
+    const addParticipant = () => {
+      this.experimenterService.createParticipant(this.experimentService.id!);
     };
 
-    const joinExperiment = async () => {
-      // Create the participant.
-      const participant = await Promise.all([addParticipant()]);
-
-      this.participantService.setParticipant(
-        this.experimentService.id,
-        participant[0].privateId
-      );
-
-      // Redirect.
-      this.routerService.navigate(
-        Pages.PARTICIPANT,
-        {
-          "experiment": this.experimentService.id!,
-          "participant": participant[0].privateId
-        }
-      );
-      this.routerService.setExperimenterNav(false);
+    const joinExperiment = () => {
+      this.experimentService.join();
     };
 
     if (!this.authService.isExperimenter) {

--- a/lit/src/experiment-components/experiment/experiment_preview.ts
+++ b/lit/src/experiment-components/experiment/experiment_preview.ts
@@ -63,19 +63,16 @@ export class ExperimentPreview extends MobxLitElement {
     }
 
     const getTransferableExperiments = () => {
-      const group = this.experimentService.experiment?.group!;
-      const currentExperimentName = this.experimentService.experiment?.name;
-      if (!currentExperimentName?.endsWith('lobby')) {
+      // Only allow transferring from the lobby.
+      if (!this.experimentService.experiment?.isLobby) {
         return [];
       }
-      // Only allow transferring from the lobby.
       // Ony fetch other, non-lobby experiments.
-      const experiments = this.experimenterService.getExperimentsInGroup(group)
-        .filter(experiment => experiment.name !== currentExperimentName
-          && !experiment.name.endsWith('lobby'));
-
-      return experiments;
+      return this.experimenterService.getExperimentsInGroup(group)
+        .filter(experiment => !experiment.isLobby);
     };
+
+    const group = this.experimentService.experiment?.group!;
 
     return html`
       <div class="top-bar">

--- a/lit/src/experiment-components/experiment/experiment_preview.ts
+++ b/lit/src/experiment-components/experiment/experiment_preview.ts
@@ -41,26 +41,30 @@ export class ExperimentPreview extends MobxLitElement {
   }
 
   override render() {
-    const addParticipant = () => {
-      this.experimenterService.createParticipant(this.experimentService.id!);
-    };
-
     const joinExperiment = () => {
       this.experimentService.join();
     };
 
     if (!this.authService.isExperimenter) {
-      return html`
-      <div class="row">
-        <pr-button
-          color="tertiary"
-          variant="tonal"
-          @click=${joinExperiment}>
-          Join experiment
-        </pr-button>
-      </div>
-      `;
+      if (this.experimentService.experiment?.isLobby) {
+        return html`
+          <div class="row">
+            <pr-button
+              color="tertiary"
+              variant="tonal"
+              @click=${joinExperiment}>
+              Join experiment
+            </pr-button>
+          </div>
+        `;
+      } else {
+        return nothing;
+      }
     }
+
+    const addParticipant = () => {
+      this.experimenterService.createParticipant(this.experimentService.id!);
+    };
 
     const getTransferableExperiments = () => {
       // Only allow transferring from the lobby.

--- a/lit/src/experiment-components/footer/footer.ts
+++ b/lit/src/experiment-components/footer/footer.ts
@@ -75,6 +75,39 @@ export class Footer extends MobxLitElement {
     const preventNextClick = this.disabled ||
       !this.participantService.isCurrentStage();
 
+    const handleTransfer = () => {
+      const transferConfig = this.participantService.profile?.transferConfig;
+      if (!transferConfig) {
+        return;
+      }
+
+      this.routerService.navigate(
+        Pages.PARTICIPANT,
+        {
+          "experiment": transferConfig.experimentId,
+          "participant": transferConfig.participantId,
+        }
+      );
+    }
+
+    // If completed lobby experiment, render link to transfer experiment
+    if (isLastStage && this.experimentService.experiment?.isLobby) {
+      // If transfer experiment has been assigned
+      if (this.participantService.profile?.transferConfig) {
+        return html`
+          <pr-button
+            variant=${this.disabled ? "default" : "tonal"}
+            ?disabled=${preventNextClick}
+            @click=${handleTransfer}
+          >
+            Go to new experiment
+          </pr-button>
+        `;
+      } else {
+        return nothing;
+      }
+    }
+
     return html`
       <pr-button
         variant=${this.disabled ? "default" : "tonal"}

--- a/lit/src/experiment-components/profile/profile_preview.ts
+++ b/lit/src/experiment-components/profile/profile_preview.ts
@@ -59,7 +59,9 @@ export class ProfilePreview extends MobxLitElement {
   }
 
   private renderTransferMenu() {
-    if (this.availableTransferExperiments.length > 0) {
+    if (!this.profile?.transferConfig &&
+        this.availableTransferExperiments.length > 0
+    ) {
       return html`
       <pr-menu name="Transfer">
         <div class="menu-wrapper">
@@ -69,7 +71,7 @@ export class ProfilePreview extends MobxLitElement {
       </pr-menu>
       `;
     }
-    return '';
+    return nothing;
   }
 
   override render() {

--- a/lit/src/experiment-components/profile/profile_preview.ts
+++ b/lit/src/experiment-components/profile/profile_preview.ts
@@ -74,6 +74,31 @@ export class ProfilePreview extends MobxLitElement {
     return nothing;
   }
 
+  renderDeleteButton() {
+    if (!this.authService.canEdit) {
+      return nothing;
+    }
+
+    const onDelete = () => {
+      this.experimenterService.deleteParticipant(
+        this.experimentService.id ?? '',
+        this.profile?.privateId ?? '',
+      );
+    };
+
+    return html`
+      <pr-tooltip text="Delete participant" position="BOTTOM_END">
+        <pr-icon-button
+          icon="delete"
+          color="error"
+          variant="default"
+          @click=${onDelete}
+        >
+        </pr-icon-button>
+      </pr-tooltip>
+    `;
+  }
+
   override render() {
     console.log(this.availableTransferExperiments)
     if (!this.profile) {
@@ -111,6 +136,7 @@ export class ProfilePreview extends MobxLitElement {
           <div class="title">${this.profile.name ?? this.profile.publicId}</div>
           <div class="subtitle">${this.profile.pronouns}</div>
         </div>
+        ${this.renderDeleteButton()}
       </div>
 
       <div>

--- a/lit/src/experiment-components/profile/profile_preview.ts
+++ b/lit/src/experiment-components/profile/profile_preview.ts
@@ -44,14 +44,18 @@ export class ProfilePreview extends MobxLitElement {
     alert("Link copied to clipboard!");
   }
 
-  async onClickTransferParticipant(e: Experiment) {
-    try {
-      const response1 = await this.experimenterService.createParticipant(e.id!, this.profile);
-      const response2 = await this.experimenterService.deleteParticipant(this.experimentService.id!, this.profile!.privateId);
-    } catch (error) {
-      console.error('Error creating participant:', error);
-      throw error;
-    }
+  private renderTransferExperimentItem(experiment: Experiment) {
+    const onTransferClick = () => {
+      this.experimenterService.transferParticipant(
+        this.experimentService.id!, experiment!.id, this.profile!
+      );
+    };
+
+    return html`
+      <div class="menu-item" role="button" @click=${onTransferClick}>
+        <div>${experiment.name}</div>
+      </div>
+    `;
   }
 
   private renderTransferMenu() {
@@ -59,11 +63,8 @@ export class ProfilePreview extends MobxLitElement {
       return html`
       <pr-menu name="Transfer">
         <div class="menu-wrapper">
-          ${this.availableTransferExperiments.map(e => html`
-            <div class="menu-item" role="button" @click=${() => this.onClickTransferParticipant(e)}>
-              <div>${e.name}</div>
-            </div>
-          `)}
+          ${this.availableTransferExperiments.map(experiment =>
+            this.renderTransferExperimentItem(experiment))}
         </div>
       </pr-menu>
       `;

--- a/lit/src/services/config/experiment_config_service.ts
+++ b/lit/src/services/config/experiment_config_service.ts
@@ -1,7 +1,9 @@
 import { collection, getDocs } from "firebase/firestore";
 import { computed, makeObservable, observable, toJS } from "mobx";
 
+import { ExperimenterService } from "../experimenter_service";
 import { FirebaseService } from "../firebase_service";
+import { Pages, RouterService } from "../router_service";
 import { Service } from "../service";
 
 import { ExperimentTemplate, randstr, StageConfig, StageKind, validateStageConfigs } from "@llm-mediation-experiments/utils";
@@ -14,7 +16,9 @@ import {
 } from "../../shared/utils";
 
 interface ServiceProvider {
+  experimenterService: ExperimenterService;
   firebaseService: FirebaseService;
+  routerService: RouterService;
 }
 
 /** Manages metadata for new experiment config. */
@@ -66,6 +70,7 @@ export class ExperimentConfigService extends Service {
         description: toJS(this.description),
         group: toJS(this.name),
         stages: convertExperimentStages(toJS(stages)),
+        isLobby: false,
         numberOfParticipants: toJS(this.numParticipants),
       });
     }
@@ -82,6 +87,7 @@ export class ExperimentConfigService extends Service {
           description: toJS(this.description),
           group: toJS(''),
           stages: toJS(this.stages),
+          isLobby: false,
           numberOfParticipants: toJS(this.numParticipants),
         }
       ];
@@ -102,6 +108,7 @@ export class ExperimentConfigService extends Service {
         description: toJS(this.description),
         group: toJS(this.name),
         stages: convertExperimentStages(toJS(preStages)),
+        isLobby: true,
         numberOfParticipants: toJS(this.numParticipants),
       });
 
@@ -298,5 +305,54 @@ export class ExperimentConfigService extends Service {
     this.currentStageIndex = -1;
     this.isGroup = false;
     this.isMultiPart = false;
+  }
+
+  async createTemplate() {
+    const { name, publicName, description, stages, numberOfParticipants } =
+      this.getExperiment();
+
+    await this.sp.experimenterService.createTemplate(
+      {
+        name,
+        description,
+        publicName,
+      }, stages
+    );
+  }
+
+  async createExperiments() {
+    const experiments = this.getExperiments();
+    let experimentId = '';
+    let groupId = '';
+
+    for (let i = 0; i < experiments.length; i++) {
+      const { name, publicName, description, stages, isLobby, numberOfParticipants, group } = experiments[i];
+      const experiment = await this.sp.experimenterService.createExperiment(
+        {
+          name,
+          publicName,
+          description,
+          isLobby,
+          numberOfParticipants,
+          group,
+        },
+        stages
+      );
+      experimentId = experiment.id;
+      groupId = group;
+    }
+
+    // Navigate to the last created experiment (or group)
+    if (groupId) {
+      this.sp.routerService.navigate(
+        Pages.EXPERIMENT_GROUP,
+        { "experiment_group": groupId }
+      );
+    } else {
+      this.sp.routerService.navigate(
+        Pages.EXPERIMENT,
+        { "experiment": experimentId }
+      );
+    }
   }
 }

--- a/lit/src/services/config/experiment_config_service.ts
+++ b/lit/src/services/config/experiment_config_service.ts
@@ -113,7 +113,7 @@ export class ExperimentConfigService extends Service {
       });
 
       // Create multiExperiments.
-      experiments.push(...this.getMultiExperiments(this.numExperiments, this.stages));
+      experiments.push(...this.getMultiExperiments(this.numExperiments, postStages));
       return experiments;
     }
 

--- a/lit/src/services/experimenter_service.ts
+++ b/lit/src/services/experimenter_service.ts
@@ -23,7 +23,7 @@ interface CreateParticipantResponse {
  * - List templates
  * - List experiment users
  * - Create experiments and templates
- * - Create and delete participants
+ * - Create, delete, and transfer participants
  */
 export class ExperimenterService extends Service {
   constructor(private readonly sp: ServiceProvider) {
@@ -202,6 +202,21 @@ export class ExperimenterService extends Service {
       experimentId: experimentId,
       participantId: participantId,
     });
+  }
+
+  /** Transfers a participant. */
+  async transferParticipant(
+    currentExperimentId: string,
+    newExperimentId: string,
+    participant: ParticipantProfileExtended
+  ) {
+    try {
+      await this.createParticipant(newExperimentId, participant);
+      await this.deleteParticipant(currentExperimentId, participant.privateId);
+    } catch (error) {
+      console.error('Error transferring participant: ', error);
+      throw error;
+    }
   }
 
   /** Delete an experiment.

--- a/lit/src/services/experimenter_service.ts
+++ b/lit/src/services/experimenter_service.ts
@@ -18,11 +18,12 @@ interface CreateParticipantResponse {
   participant: ParticipantProfileExtended
 }
 
-/** Handle experimenter-related data:
+/** Handle experimenter-related actions:
  * - List experiments
  * - List templates
  * - List experiment users
  * - Create experiments and templates
+ * - Create and delete participants
  */
 export class ExperimenterService extends Service {
   constructor(private readonly sp: ServiceProvider) {

--- a/lit/src/services/experimenter_service.ts
+++ b/lit/src/services/experimenter_service.ts
@@ -154,13 +154,14 @@ export class ExperimenterService extends Service {
     const description = experiment.description ?? '';
     const tags = experiment.tags ?? [];
     const group = experiment.group ?? '';
+    const isLobby = experiment.isLobby ?? false;
     const numberOfParticipants = experiment.numberOfParticipants ?? 1;
 
     return createExperimentCallable(
       this.sp.firebaseService.functions,
       {
         type: 'experiments',
-        metadata: { name, publicName, description, tags, group, numberOfParticipants },
+        metadata: { name, publicName, description, tags, group, isLobby, numberOfParticipants },
         stages,
       }
     );
@@ -175,13 +176,14 @@ export class ExperimenterService extends Service {
     const description = experiment.description ?? '';
     const tags = experiment.tags ?? [];
     const group = experiment.group ?? '';
+    const isLobby = experiment.isLobby ?? false;
     const numberOfParticipants = experiment.numberOfParticipants ?? 1;
 
     return createExperimentCallable(
       this.sp.firebaseService.functions,
       {
         type: 'templates',
-        metadata: { name, publicName, description, tags, group, numberOfParticipants },
+        metadata: { name, publicName, description, tags, group, isLobby, numberOfParticipants },
         stages,
       }
     );

--- a/utils/src/types/experiments.types.ts
+++ b/utils/src/types/experiments.types.ts
@@ -20,6 +20,7 @@ export interface Experiment {
   tags: string[];
   author: Experimenter;
   starred: Record<string, boolean>; // maps from experimenter ID to isStarred
+  isLobby: boolean; // true if lobby experiment
   date: UnifiedTimestamp;
   numberOfParticipants: number;
 

--- a/utils/src/types/participants.types.ts
+++ b/utils/src/types/participants.types.ts
@@ -18,11 +18,18 @@ export interface ParticipantProfileBase {
 export interface ParticipantProfile extends ParticipantProfileBase {
   publicId: string; // Public identifier for the participant inside an experiment
   currentStageId: string;
+  transferConfig: ExperimentTransferConfig|null;
 }
 
 /** For experimenters to be aware of the private ID */
 export interface ParticipantProfileExtended extends ParticipantProfile {
   privateId: string;
+}
+
+/** Experiment transfer config. */
+export interface ExperimentTransferConfig {
+  experimentId: string;
+  participantId: string;
 }
 
 export const participantPublicId = (index: number) => `participant-${index}`;

--- a/utils/src/validation/experiments.validation.ts
+++ b/utils/src/validation/experiments.validation.ts
@@ -67,6 +67,7 @@ export const ExperimentCreationData = Type.Object(
         description: Type.String(),
         tags: Type.Array(Type.String()),
         group: Type.Optional(Type.String()),
+        isLobby: Type.Boolean(),
         numberOfParticipants: Type.Optional(Type.Number({ minimum: 1 })),
       },
       strict,


### PR DESCRIPTION
Changes discussed in #145:

https://github.com/user-attachments/assets/43e329ea-ee39-4e0a-b698-7f6d6b7d85fa

- create/delete functions have been refactored to services instead of UI components
- added isLobby field to experiment
- added transferConfig to experiment to specify the transfer experiment/participant IDs
- added button for participant to self-diretc themselves to the new experiment (once the experimenter has assigned it)
- deleteParticipant function is still present in experimenterService, but not called
- transferred participants are sorted at the bottom of experiment_preview page

Note that the following change has not yet been implemented:
- when creating multi-group (lobby) experiments, start all experiments with 0 participants (as lobby participants will self-join and non-lobby experiment participants will be assigned by experimenters)