### PR TITLE
Fix backwards compatibility rendering for experiments (minus experime…

### DIFF
--- a/lit/src/components/header/header.ts
+++ b/lit/src/components/header/header.ts
@@ -150,8 +150,10 @@ export class Header extends MobxLitElement {
         const experiment = this.experimentService.experiment; 
         if (!this.authService.isExperimenter) {
           return experiment?.publicName ?? "Experiment";
+        } else if (experiment && experiment.publicName) {
+          return `${experiment.publicName} (${experiment.name})`;
         }
-        return experiment ? `${experiment.publicName} (${experiment.name})` : "Experiment";
+        return "Experiment";
 
       case Pages.EXPERIMENT_GROUP:
         return "Experiment group: " + this.routerService.activeRoute.params["experiment_group"];

--- a/lit/src/components/landing/experiment_card.ts
+++ b/lit/src/components/landing/experiment_card.ts
@@ -77,7 +77,7 @@ export class ExperimentCard extends MobxLitElement {
         <div class="action-buttons">
           
         <div class="label">
-          <div>${this.experiment!.author.displayName}</div>
+          <div>${this.experiment!.author?.displayName ?? ''}</div>
           <small>${convertUnifiedTimestampToDate(this.experiment!.date)}</small>
         </div>
       </div>`;

--- a/lit/src/components/landing/experiment_landing.ts
+++ b/lit/src/components/landing/experiment_landing.ts
@@ -98,7 +98,7 @@ export class ExperimentLanding extends MobxLitElement {
         <div>
           <p>${experiments.length} experiments</p>
           <div class="label">
-            <div>${experiments[0].author.displayName}</div>
+            <div>${experiments[0].author?.displayName ?? ''}</div>
             <small>${convertUnifiedTimestampToDate(experiments[0].date)}</small>
           </div>
         </div>

--- a/lit/src/experiment-components/experiment/experiment_preview.ts
+++ b/lit/src/experiment-components/experiment/experiment_preview.ts
@@ -89,8 +89,8 @@ export class ExperimentPreview extends MobxLitElement {
       <div class="top-bar">
         <div class="left">
           <div class="stat small">
-            Public experiment name: ${experiment?.publicName} <br/>
-            Author: ${experiment?.author.displayName} <br/>
+            ${experiment?.publicName ? `Public experiment name: ${experiment?.publicName} <br/>` : ''}
+            ${experiment?.author && experiment?.author.displayName ? `Author: ${experiment?.author.displayName} <br/>` : ''}
             Create time: ${convertUnifiedTimestampToDate(experiment?.date!)} <br/>
             ${experiment?.numberOfMaxParticipants ? html`
             Maximum number of participants: ${experiment?.numberOfMaxParticipants} <br/>

--- a/lit/src/experiment-components/profile/profile_preview.ts
+++ b/lit/src/experiment-components/profile/profile_preview.ts
@@ -100,7 +100,6 @@ export class ProfilePreview extends MobxLitElement {
   }
 
   override render() {
-    console.log(this.availableTransferExperiments)
     if (!this.profile) {
       return nothing;
     }
@@ -192,14 +191,15 @@ export class ProfilePreview extends MobxLitElement {
             @click=${handlePreview}>
           </pr-button>
         </pr-tooltip>
-        <pr-tooltip text="Preview transfer as participant" position="TOP_END">
+        ${this.profile.transferConfig ? 
+          html`<pr-tooltip text="Preview transfer as participant" position="TOP_END">
           <pr-icon-button
             icon="mystery"
             color="primary"
             variant="default"
             @click=${handleFuturePreview}>
           </pr-button>
-        </pr-tooltip>
+        </pr-tooltip>` : ''}
         <pr-tooltip text="Copy participant link" position="TOP_END">
           <pr-icon-button
             icon="content_copy"


### PR DESCRIPTION
Fixes rendering. "Preview" and "get current stage" within participant breaks now that we've re-routed the stages to stageId, however, so we can't look at old experiments.