### PR TITLE
Use drag-and-drop ordered list for election

### DIFF
--- a/functions/src/endpoints/experiments.endpoints.ts
+++ b/functions/src/endpoints/experiments.endpoints.ts
@@ -156,6 +156,7 @@ export const createExperiment = onCall(async (request) => {
           completedExperiment: null,
           transferConfig: null,
           prolificId: null,
+          completionType: null,
         };
 
         // Create the participant document
@@ -276,6 +277,7 @@ export const createParticipant = onCall(async (request) => {
       completedExperiment: null,
       transferConfig: null,
       prolificId: data.participantData?.prolificId ?? data.prolificId ?? null,
+      completionType: null,
     };
 
     // Increment the number of participants in the experiment metadata

--- a/functions/src/endpoints/experiments.endpoints.ts
+++ b/functions/src/endpoints/experiments.endpoints.ts
@@ -57,6 +57,7 @@ export const createExperiment = onCall(async (request) => {
         numberOfMaxParticipants,
         waitForAllToStart,
         prolificRedirectCode,
+        attentionCheckParams,
       } = data.metadata;
 
       // Create the metadata document
@@ -71,6 +72,7 @@ export const createExperiment = onCall(async (request) => {
         numberOfMaxParticipants,
         waitForAllToStart,
         prolificRedirectCode,
+        attentionCheckParams,
         ...(data.type === 'experiments'
           ? {
               date: Timestamp.now(),

--- a/functions/src/endpoints/participants.endpoints.ts
+++ b/functions/src/endpoints/participants.endpoints.ts
@@ -26,9 +26,9 @@ export const updateStage = onCall(async (request) => {
     // Validation & merging answers
     switch (stage.kind) {
       case StageKind.VoteForLeader:
-        if (participantId in stage.votes)
+        if (participantId in stage.rankings)
           throw new functions.https.HttpsError('invalid-argument', 'Invalid answers');
-        await answerDoc.set({ kind: StageKind.VoteForLeader, votes: stage.votes }, { merge: true });
+        await answerDoc.set({ kind: StageKind.VoteForLeader, rankings: stage.rankings }, { merge: true });
         break;
 
       case StageKind.TakeSurvey:

--- a/functions/src/triggers/stages.triggers.ts
+++ b/functions/src/triggers/stages.triggers.ts
@@ -10,6 +10,7 @@ import {
   StageConfig,
   StageKind,
   VoteForLeaderStagePublicData,
+  getCondorcetElectionWinner,
 } from '@llm-mediation-experiments/utils';
 import { Timestamp } from 'firebase-admin/firestore';
 import { onDocumentWritten } from 'firebase-functions/v2/firestore';
@@ -141,12 +142,11 @@ export const publishStageData = onDocumentWritten(
           .get();
         const publicData = publicDoc.data() as VoteForLeaderStagePublicData;
 
-        // TODO: Compute the new leader with these rankings
-        const currentLeader = participantPublicId; // Temporarily set current participant to leader
-
-        // Participant rankings
+        // Update participant rankings
         const participantRankings = publicData.participantRankings;
         participantRankings[participantPublicId] = data.rankings;
+
+        const currentLeader = getCondorcetElectionWinner(participantRankings);
 
         // Update the public data
         await publicDoc.ref.update({

--- a/functions/src/triggers/stages.triggers.ts
+++ b/functions/src/triggers/stages.triggers.ts
@@ -10,8 +10,6 @@ import {
   StageConfig,
   StageKind,
   VoteForLeaderStagePublicData,
-  allVoteScores,
-  chooseLeader,
 } from '@llm-mediation-experiments/utils';
 import { Timestamp } from 'firebase-admin/firestore';
 import { onDocumentWritten } from 'firebase-functions/v2/firestore';
@@ -30,7 +28,7 @@ export const initializePublicStageData = onDocumentWritten(
       case StageKind.VoteForLeader:
         publicData = {
           kind: data.kind,
-          participantvotes: {},
+          participantRankings: {},
           currentLeader: null,
         };
         break;
@@ -143,16 +141,16 @@ export const publishStageData = onDocumentWritten(
           .get();
         const publicData = publicDoc.data() as VoteForLeaderStagePublicData;
 
-        // Compute the updated votes
-        const newVotes = publicData.participantvotes;
-        newVotes[participantPublicId] = data.votes;
+        // TODO: Compute the new leader with these rankings
+        const currentLeader = participantPublicId; // Temporarily set current participant to leader
 
-        // Compute the new leader with these votes
-        const currentLeader = chooseLeader(allVoteScores(newVotes));
+        // Participant rankings
+        const participantRankings = publicData.participantRankings;
+        participantRankings[participantPublicId] = data.rankings;
 
         // Update the public data
         await publicDoc.ref.update({
-          participantvotes: newVotes,
+          participantRankings,
           currentLeader,
         });
 

--- a/lit/src/app.ts
+++ b/lit/src/app.ts
@@ -94,7 +94,7 @@ export class App extends MobxLitElement {
       case Pages.PARTICIPANT_STAGE:
         if (
           !this.authService.isExperimenter &&
-          this.experimentService.experiment?.attentionCheckParams
+          this.experimentService.experiment?.attentionCheckParams?.waitSeconds
         ) {
           return html` <attention-check-popup
               waitSeconds=${this.experimentService.experiment

--- a/lit/src/app.ts
+++ b/lit/src/app.ts
@@ -92,11 +92,15 @@ export class App extends MobxLitElement {
       case Pages.PARTICIPANT:
         return this.renderParticipantView(this.renderParticipant());
       case Pages.PARTICIPANT_STAGE:
-        // TODO: Ignore this for experimenters, and allow experimenters to add this.
-        if (false) {
+        if (
+          !this.authService.isExperimenter &&
+          this.experimentService.experiment?.attentionCheckParams
+        ) {
           return html` <attention-check-popup
-              waitSeconds="120"
-              popupSeconds="60"
+              waitSeconds=${this.experimentService.experiment
+                ?.attentionCheckParams.waitSeconds}
+              popupSeconds=${this.experimentService.experiment
+                ?.attentionCheckParams.popupSeconds}
             ></attention-check-popup>
             ${this.renderParticipantView(this.renderParticipantStage())}`;
         }

--- a/lit/src/components/header/header.ts
+++ b/lit/src/components/header/header.ts
@@ -1,31 +1,29 @@
-import "../../pair-components/button";
-import "../../pair-components/icon_button";
-import "../../pair-components/info_popup";
-import "../../pair-components/menu";
-import "../../pair-components/tooltip";
+import '../../pair-components/button';
+import '../../pair-components/icon_button';
+import '../../pair-components/info_popup';
+import '../../pair-components/menu';
+import '../../pair-components/tooltip';
 
-import "../../experiment-components/experiment/experiment_config_menu";
+import '../../experiment-components/experiment/experiment_config_menu';
 
-import { MobxLitElement } from "@adobe/lit-mobx";
-import { CSSResultGroup, html, nothing } from "lit";
-import { customElement } from "lit/decorators.js";
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement} from 'lit/decorators.js';
 
-import { core } from "../../core/core";
-import { AuthService } from "../../services/auth_service";
-import {
-  ExperimentConfigService
-} from "../../services/config/experiment_config_service";
-import { ExperimentService } from "../../services/experiment_service";
-import { ExperimenterService } from "../../services/experimenter_service";
-import { ParticipantService } from "../../services/participant_service";
-import { Pages, RouterService } from "../../services/router_service";
+import {core} from '../../core/core';
+import {AuthService} from '../../services/auth_service';
+import {ExperimentConfigService} from '../../services/config/experiment_config_service';
+import {ExperimentService} from '../../services/experiment_service';
+import {ExperimenterService} from '../../services/experimenter_service';
+import {ParticipantService} from '../../services/participant_service';
+import {Pages, RouterService} from '../../services/router_service';
 
-import { ExperimentTemplate } from "@llm-mediation-experiments/utils";
+import {ExperimentTemplate} from '@llm-mediation-experiments/utils';
 
-import { styles } from "./header.scss";
+import {styles} from './header.scss';
 
 /** Header component for app pages */
-@customElement("page-header")
+@customElement('page-header')
 export class Header extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
@@ -44,9 +42,7 @@ export class Header extends MobxLitElement {
           ${this.renderBackButton()}
           <h1>${this.renderTitle()}</h1>
         </div>
-        <div class="right">
-          ${this.renderActions()}
-        </div>
+        <div class="right">${this.renderActions()}</div>
       </div>
     `;
   }
@@ -66,23 +62,25 @@ export class Header extends MobxLitElement {
           icon=${this.authService.canEdit ? 'edit_off' : 'edit'}
           color="primary"
           variant="default"
-          @click=${toggleEdit}>
+          @click=${toggleEdit}
+        >
         </pr-icon-button>
       </pr-tooltip>
     `;
   }
 
   private renderAuthBanner() {
-    if (!this.authService.isExperimenter
-      || !this.routerService.isParticipantPage) {
+    if (
+      !this.authService.isExperimenter ||
+      !this.routerService.isParticipantPage
+    ) {
       return nothing;
     }
 
     const handlePreviewOff = () => {
-      this.routerService.navigate(
-        Pages.EXPERIMENT,
-        { "experiment": this.routerService.activeRoute.params["experiment"] }
-      );
+      this.routerService.navigate(Pages.EXPERIMENT, {
+        experiment: this.routerService.activeRoute.params['experiment'],
+      });
       this.authService.setEditPermissions(false);
       this.routerService.setExperimenterNav(true);
     };
@@ -106,7 +104,8 @@ export class Header extends MobxLitElement {
           <div>
             You are previewing as
             ${participantName ? `${participantName} / ` : 'Participant '}
-            ${this.participantService.profile?.publicId}.
+            ${this.participantService.profile?.publicId} (attention checks are
+            disabled in experimenter mode).
           </div>
         </div>
       </div>
@@ -124,14 +123,15 @@ export class Header extends MobxLitElement {
     const handleClick = () => {
       this.routerService.navigate(Pages.HOME);
       this.authService.setEditPermissions(false);
-    }
+    };
 
     return html`
       <pr-icon-button
         color="neutral"
         icon="arrow_back"
         variant="default"
-        @click=${handleClick}>
+        @click=${handleClick}
+      >
       </pr-icon-button>
     `;
   }
@@ -141,32 +141,36 @@ export class Header extends MobxLitElement {
 
     switch (activePage) {
       case Pages.HOME:
-        return "Home";
+        return 'Home';
       case Pages.SETTINGS:
-        return "Settings";
+        return 'Settings';
       case Pages.PARTICIPANT_SETTINGS:
-        return "Settings";
+        return 'Settings';
       case Pages.EXPERIMENT:
-        const experiment = this.experimentService.experiment; 
+        const experiment = this.experimentService.experiment;
         if (!this.authService.isExperimenter) {
-          return experiment?.publicName ?? "Experiment";
+          return experiment?.publicName ?? 'Experiment';
         } else if (experiment && experiment.publicName) {
           return `${experiment.publicName} (${experiment.name})`;
         }
-        return "Experiment";
+        return 'Experiment';
 
       case Pages.EXPERIMENT_GROUP:
-        return "Experiment group: " + this.routerService.activeRoute.params["experiment_group"];
+        return (
+          'Experiment group: ' +
+          this.routerService.activeRoute.params['experiment_group']
+        );
       case Pages.EXPERIMENT_CREATE:
-        return "New experiment";
+        return 'New experiment';
       case Pages.PARTICIPANT:
-        return "Welcome, participant!";
+        return 'Welcome, participant!';
       case Pages.PARTICIPANT_STAGE:
         return this.experimentService.getStageName(
-          this.routerService.activeRoute.params["stage"], true
+          this.routerService.activeRoute.params['stage'],
+          true
         );
       default:
-        return "";
+        return '';
     }
   }
 
@@ -176,15 +180,14 @@ export class Header extends MobxLitElement {
     switch (activePage) {
       case Pages.HOME:
         return html`
-          ${this.renderCreateExperimentButton()}
-          ${this.renderEditPermissions()}
+          ${this.renderCreateExperimentButton()} ${this.renderEditPermissions()}
         `;
       case Pages.EXPERIMENT_GROUP:
         return this.renderEditPermissions();
       case Pages.EXPERIMENT:
         return this.renderEditPermissions();
       case Pages.PARTICIPANT_STAGE:
-        const stageName = this.routerService.activeRoute.params["stage"];
+        const stageName = this.routerService.activeRoute.params['stage'];
         const currentStage = this.experimentService.getStage(stageName);
         if (currentStage && currentStage.popupText) {
           return html`
@@ -206,7 +209,7 @@ export class Header extends MobxLitElement {
 
     const handleClick = () => {
       this.routerService.navigate(Pages.EXPERIMENT_CREATE);
-    }
+    };
 
     return html`
       <pr-button padding="small" variant="tonal" @click=${handleClick}>
@@ -232,10 +235,12 @@ export class Header extends MobxLitElement {
     return html`
       <pr-menu color="secondary" name="Load template">
         <div class="menu-wrapper">
-          ${this.experimenterService.templates.length === 0 ?
-            html`<div>No templates yet</div>` : nothing}
-          ${this.experimenterService.templates.map(
-            template => this.renderExperimentConfigTemplateItem(template))}
+          ${this.experimenterService.templates.length === 0
+            ? html`<div>No templates yet</div>`
+            : nothing}
+          ${this.experimenterService.templates.map((template) =>
+            this.renderExperimentConfigTemplateItem(template)
+          )}
         </div>
       </pr-menu>
       <experiment-config-menu></experiment-config-menu>
@@ -245,6 +250,6 @@ export class Header extends MobxLitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "page-header": Header;
+    'page-header': Header;
   }
 }

--- a/lit/src/components/landing/experiment_card.ts
+++ b/lit/src/components/landing/experiment_card.ts
@@ -55,14 +55,12 @@ export class ExperimentCard extends MobxLitElement {
       return numCompleted;
     };
 
-    const participantTimeoutCount = () => {
+    const participantFailedCount = () => {
       let numCompleted = 0;
       for (const participant of Object.values(this.experiment!.participants)) {
         if (
-          participant.completionType ===
-            PARTICIPANT_COMPLETION_TYPE.LOBBY_TIMEOUT ||
-          participant.completionType ===
-            PARTICIPANT_COMPLETION_TYPE.ATTENTION_TIMEOUT
+          participant.completionType &&
+          !(participant.completionType === PARTICIPANT_COMPLETION_TYPE.SUCCESS)
         ) {
           numCompleted += 1;
         }
@@ -92,8 +90,8 @@ export class ExperimentCard extends MobxLitElement {
       return participantSuccessCount() / this.experiment!.numberOfParticipants;
     };
 
-    const participantTimeoutRatio = () => {
-      return participantTimeoutCount() / this.experiment!.numberOfParticipants;
+    const participantFailedRatio = () => {
+      return participantFailedCount() / this.experiment!.numberOfParticipants;
     };
 
     const renderGroupMetadata = () => {
@@ -115,8 +113,8 @@ export class ExperimentCard extends MobxLitElement {
       }
 
       return html`<pr-tooltip
-        text="${participantSuccessCount()} completed, ${participantTimeoutCount()
-          ? `, ${participantTimeoutCount()} timed out, `
+        text="${participantSuccessCount()} completed, ${participantFailedCount()
+          ? `, ${participantFailedCount()} timed out, `
           : ''}${participantProgressCount()} in progress"
         position="BOTTOM_START"
       >
@@ -127,7 +125,7 @@ export class ExperimentCard extends MobxLitElement {
           ></div>
           <div
             class="progress timeout"
-            style="width: calc(100% * ${participantTimeoutRatio()})"
+            style="width: calc(100% * ${participantFailedRatio()})"
           ></div>
 
           <div

--- a/lit/src/components/landing/experiment_card.ts
+++ b/lit/src/components/landing/experiment_card.ts
@@ -1,27 +1,28 @@
-import "../../pair-components/button";
-import "../../pair-components/icon_button";
-import "../../pair-components/tooltip";
+import '../../pair-components/button';
+import '../../pair-components/icon_button';
+import '../../pair-components/tooltip';
 
-import { MobxLitElement } from "@adobe/lit-mobx";
-import { CSSResultGroup, html, nothing } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
 
-import { Experiment } from '@llm-mediation-experiments/utils';
-import { convertUnifiedTimestampToDate } from '../../shared/utils';
+import {Experiment} from '@llm-mediation-experiments/utils';
+import {convertUnifiedTimestampToDate} from '../../shared/utils';
 
-import { core } from "../../core/core";
-import { AuthService } from "../../services/auth_service";
-import { ExperimenterService } from "../../services/experimenter_service";
-import { Pages, RouterService } from "../../services/router_service";
+import {core} from '../../core/core';
+import {AuthService} from '../../services/auth_service';
+import {ExperimenterService} from '../../services/experimenter_service';
+import {Pages, RouterService} from '../../services/router_service';
 
-import { styles } from "./experiment_card.scss";
+import {PARTICIPANT_COMPLETION_TYPE} from '@llm-mediation-experiments/utils';
+import {styles} from './experiment_card.scss';
 
 /** Experiment card component */
-@customElement("experiment-card")
+@customElement('experiment-card')
 export class ExperimentCard extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
-  @property() experiment: Experiment|null = null;
+  @property() experiment: Experiment | null = null;
   // Whether to show properties that are the same across the group.
   @property() showGroup: boolean = true;
 
@@ -35,77 +36,106 @@ export class ExperimentCard extends MobxLitElement {
     }
 
     const handleClick = () => {
-      this.routerService.navigate(
-        Pages.EXPERIMENT,
-        { "experiment": this.experiment!.id }
-      );
+      this.routerService.navigate(Pages.EXPERIMENT, {
+        experiment: this.experiment!.id,
+      });
       this.authService.setEditPermissions(false);
-    }
+    };
 
-    const participantCompletedCount = () => {
+    const participantSuccessCount = () => {
       let numCompleted = 0;
       for (const participant of Object.values(this.experiment!.participants)) {
-        if (participant.completedExperiment) {
+        if (
+          participant.completionType === PARTICIPANT_COMPLETION_TYPE.SUCCESS ||
+          (participant.completedExperiment && !participant.completionType)
+        ) {
           numCompleted += 1;
         }
       }
       return numCompleted;
-    }
+    };
+
+    const participantTimeoutCount = () => {
+      let numCompleted = 0;
+      for (const participant of Object.values(this.experiment!.participants)) {
+        if (
+          participant.completionType ===
+            PARTICIPANT_COMPLETION_TYPE.LOBBY_TIMEOUT ||
+          participant.completionType ===
+            PARTICIPANT_COMPLETION_TYPE.ATTENTION_TIMEOUT
+        ) {
+          numCompleted += 1;
+        }
+      }
+      return numCompleted;
+    };
 
     const participantProgressCount = () => {
       // Only counts if started and NOT completed
       let numStarted = 0;
       for (const participant of Object.values(this.experiment!.participants)) {
-        if (participant.acceptTosTimestamp && !participant.completedExperiment) {
+        if (
+          participant.acceptTosTimestamp &&
+          !participant.completedExperiment
+        ) {
           numStarted += 1;
         }
       }
       return numStarted;
-    }
+    };
 
     const participantProgressRatio = () => {
       return participantProgressCount() / this.experiment!.numberOfParticipants;
-    }
+    };
 
-    const participantCompletedRatio = () => {
-      return participantCompletedCount() / this.experiment!.numberOfParticipants;
-    }
+    const participantSuccessRatio = () => {
+      return participantSuccessCount() / this.experiment!.numberOfParticipants;
+    };
+
+    const participantTimeoutRatio = () => {
+      return participantTimeoutCount() / this.experiment!.numberOfParticipants;
+    };
 
     const renderGroupMetadata = () => {
       if (this.showGroup) {
-        return html`
-        <div class="action-buttons">
-          
-        <div class="label">
-          <div>${this.experiment!.author?.displayName ?? ''}</div>
-          <small>${convertUnifiedTimestampToDate(this.experiment!.date)}</small>
-        </div>
-      </div>`;
+        return html` <div class="action-buttons">
+          <div class="label">
+            <div>${this.experiment!.author?.displayName ?? ''}</div>
+            <small
+              >${convertUnifiedTimestampToDate(this.experiment!.date)}</small
+            >
+          </div>
+        </div>`;
       }
-    }
+    };
 
-    const renderParticipantProgressBar = () =>  {
+    const renderParticipantProgressBar = () => {
       if (!this.experiment!.numberOfParticipants) {
         return;
       }
-      
+
       return html`<pr-tooltip
-            text="${participantCompletedCount()} completed, ${participantProgressCount()} in progress"
-            position="BOTTOM_START"
-          >
-            <div class="progress-bar">
-              <div
-                class="progress completed"
-                style="width: calc(100% * ${participantCompletedRatio()})"
-              >
-              </div>
-              <div
-                class="progress in-progress"
-                style="width: calc(100% * .5 * ${participantProgressRatio()})"
-              >
-              </div>
-            </div>`;
-    }
+        text="${participantSuccessCount()} completed, ${participantTimeoutCount()
+          ? `, ${participantTimeoutCount()} timed out, `
+          : ''}${participantProgressCount()} in progress"
+        position="BOTTOM_START"
+      >
+        <div class="progress-bar">
+          <div
+            class="progress completed"
+            style="width: calc(100% * ${participantSuccessRatio()})"
+          ></div>
+          <div
+            class="progress timeout"
+            style="width: calc(100% * ${participantTimeoutRatio()})"
+          ></div>
+
+          <div
+            class="progress in-progress"
+            style="width: calc(100% * .5 * ${participantProgressRatio()})"
+          ></div></div
+      ></pr-tooltip>`;
+    };
 
     return html`
       <div class="header">
@@ -141,16 +171,16 @@ export class ExperimentCard extends MobxLitElement {
 
     const navigateToGroup = () => {
       if (this.experiment!.group) {
-        this.routerService.navigate(
-          Pages.EXPERIMENT_GROUP,
-          { "experiment_group": this.experiment!.group }
-        );
+        this.routerService.navigate(Pages.EXPERIMENT_GROUP, {
+          experiment_group: this.experiment!.group,
+        });
         this.authService.setEditPermissions(false);
       }
     };
 
     return html`
-      <div class="field">Group:
+      <div class="field">
+        Group:
         <div class="chip secondary" role="button" @click=${navigateToGroup}>
           ${this.experiment.group}
         </div>
@@ -169,7 +199,8 @@ export class ExperimentCard extends MobxLitElement {
           icon="delete"
           color="error"
           variant="default"
-          @click=${handleDelete}>
+          @click=${handleDelete}
+        >
         </pr-icon-button>
       </pr-tooltip>
     `;
@@ -178,6 +209,6 @@ export class ExperimentCard extends MobxLitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "experiment-card": ExperimentCard;
+    'experiment-card': ExperimentCard;
   }
 }

--- a/lit/src/experiment-components/attention_check/attention_check_popup.ts
+++ b/lit/src/experiment-components/attention_check/attention_check_popup.ts
@@ -1,6 +1,7 @@
-import "../../pair-components/icon";
+import '../../pair-components/icon';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
+import {PARTICIPANT_COMPLETION_TYPE} from '@llm-mediation-experiments/utils';
 import {CSSResultGroup, html, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {core} from '../../core/core';
@@ -96,13 +97,17 @@ export class AttentionCheckPopup extends MobxLitElement {
   private handleFailedAttentionCheck = () => {
     this.showAttentionCheck = false;
     alert('Attention check failed.');
-    this.participantService.markExperimentCompleted();
+    this.participantService.markExperimentCompleted(
+      PARTICIPANT_COMPLETION_TYPE.ATTENTION_TIMEOUT
+    );
 
     if (this.experimentService.experiment?.prolificRedirectCode) {
-      // Navigate to Prolific with completion code.
-      window.location.href =
-        PROLIFIC_COMPLETION_URL_PREFIX +
+      const redirectCode =
+        this.experimentService.experiment?.attentionCheckParams!
+          .prolificAttentionFailRedirectCode ??
         this.experimentService.experiment?.prolificRedirectCode;
+      // Navigate to Prolific with completion code.
+      window.location.href = PROLIFIC_COMPLETION_URL_PREFIX + redirectCode;
     } else {
       // TODO: navigate to an end-of-experiment payout page
       this.routerService.navigate(Pages.HOME);
@@ -125,7 +130,11 @@ export class AttentionCheckPopup extends MobxLitElement {
             <div>Time remaining until experiment ends:</div>
             <div class="time">${this.countdown} seconds</div>
           </div>
-          <pr-button color="secondary" variant="tonal" @click=${this.handleAttentionCheckResponse}>
+          <pr-button
+            color="secondary"
+            variant="tonal"
+            @click=${this.handleAttentionCheckResponse}
+          >
             Yes, continue experiment
           </pr-button>
         </div>

--- a/lit/src/experiment-components/chat/lost_at_sea_chat.ts
+++ b/lit/src/experiment-components/chat/lost_at_sea_chat.ts
@@ -1,36 +1,38 @@
-import "../../pair-components/button";
-import "../../pair-components/icon_button";
-import "../../pair-components/tooltip";
+import '../../pair-components/button';
+import '../../pair-components/icon_button';
+import '../../pair-components/tooltip';
 
-import "../footer/footer";
-import "../profile/profile_avatar";
-import "../progress/progress_end_chat";
-import "../progress/progress_stage_waiting";
-import "./chat_interface";
+import '../footer/footer';
+import '../mediators/mediator_config';
+import '../profile/profile_avatar';
+import '../progress/progress_end_chat';
+import '../progress/progress_stage_waiting';
+import './chat_interface';
 
-import { MobxLitElement } from "@adobe/lit-mobx";
-import { CSSResultGroup, html, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
-
-import { core } from "../../core/core";
-import { AuthService } from "../../services/auth_service";
-import { ChatService } from "../../services/chat_service";
-import { ExperimentService } from "../../services/experiment_service";
-import { ParticipantService } from "../../services/participant_service";
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement, property, state} from 'lit/decorators.js';
 
 import {
   ChatKind,
   GroupChatStageConfig,
   ItemName,
-  ITEMS
-} from "@llm-mediation-experiments/utils";
+  ITEMS,
+} from '@llm-mediation-experiments/utils';
+import {unsafeHTML} from 'lit/directives/unsafe-html.js';
+import {core} from '../../core/core';
+import {AuthService} from '../../services/auth_service';
+import {ChatService} from '../../services/chat_service';
+import {ExperimentService} from '../../services/experiment_service';
+import {ParticipantService} from '../../services/participant_service';
+import {convertMarkdownToHTML} from '../../shared/utils';
 
-  import { getChatRatingsToDiscuss } from "../../shared/utils";
+import {createMediator, getChatRatingsToDiscuss} from '../../shared/utils';
 
-import { styles } from "./lost_at_sea_chat.scss";
+import {styles} from './lost_at_sea_chat.scss';
 
 /** Ranking chat stage (discuss different item pairs). */
-@customElement("lost-at-sea-chat")
+@customElement('lost-at-sea-chat')
 export class RankingChat extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
@@ -39,21 +41,29 @@ export class RankingChat extends MobxLitElement {
   private readonly experimentService = core.getService(ExperimentService);
   private readonly participantService = core.getService(ParticipantService);
 
-  @property() stage: GroupChatStageConfig|null = null;
+  @property() stage: GroupChatStageConfig | null = null;
 
-  @state() value = "";
+  @state() value = '';
+  @state() mediator = createMediator();
+  @state() showMediationPanel = false;
 
   override render() {
-    if (this.stage === null ||
-        this.stage.chatConfig.kind !== ChatKind.ChatAboutItems) {
+    if (
+      this.stage === null ||
+      this.stage.chatConfig.kind !== ChatKind.ChatAboutItems
+    ) {
       return nothing;
     }
 
     const currentStage = this.stage.id!;
-    const { ready, notReady } =
+    const {ready, notReady} =
       this.experimentService.getParticipantsReadyForStage(currentStage);
 
-    const descriptionContent = this.stage.description ? html`<div class="description">${this.stage.description}</div>` : '';
+    const descriptionContent = this.stage.description
+      ? html`<div class="description">
+          ${unsafeHTML(convertMarkdownToHTML(this.stage.description))}
+        </div>`
+      : '';
     if (notReady.length > 0) {
       return html`
         ${descriptionContent}
@@ -61,24 +71,24 @@ export class RankingChat extends MobxLitElement {
         </progress-stage-waiting>
       `;
     }
-    const hasChatEnded = this.stage.chatConfig.ratingsToDiscuss.length <= this.chatService.getCurrentRatingIndex(); 
+    const hasChatEnded =
+      this.stage.chatConfig.ratingsToDiscuss.length <=
+      this.chatService.getCurrentRatingIndex();
 
     const numDiscussions = getChatRatingsToDiscuss(this.stage!).length;
-    const showNext =
-      this.chatService.getCurrentRatingIndex() >= numDiscussions;
+    const showNext = this.chatService.getCurrentRatingIndex() >= numDiscussions;
 
     return html`
       ${descriptionContent}
       <div class="chat-interface-wrapper">
         <div class="panel">
-          ${this.renderParticipants()}
-          ${this.renderTask()}
-          ${this.renderEndDiscussion()}
+          ${this.renderParticipants()} ${this.renderTask()}
+          ${this.renderEndDiscussion()} ${this.renderMediationButton()}
         </div>
+        ${this.renderMediationPanel()}
         <chat-interface .disableInput=${hasChatEnded}></chat-interface>
       </div>
-      <stage-footer .disabled=${!showNext}>
-      </stage-footer>
+      <stage-footer .disabled=${!showNext}> </stage-footer>
     `;
   }
 
@@ -86,13 +96,15 @@ export class RankingChat extends MobxLitElement {
     return html`
       <div class="panel-item">
         <div class="panel-item-title">Participants</div>
-        ${this.experimentService.getParticipantProfiles().map(p =>
-          html`
-            <div class="profile">
-              <profile-avatar .emoji=${p.avatarUrl}></profile-avatar>
-              <div>${p.name} (${p.pronouns})</div>
-            </div>
-          `)}
+        ${this.experimentService.getParticipantProfiles().map(
+          (p) =>
+            html`
+              <div class="profile">
+                <profile-avatar .emoji=${p.avatarUrl}></profile-avatar>
+                <div>${p.name} (${p.pronouns})</div>
+              </div>
+            `
+        )}
       </div>
     `;
   }
@@ -125,8 +137,6 @@ export class RankingChat extends MobxLitElement {
     const length = getChatRatingsToDiscuss(this.stage!).length;
     const pair = ratings[Math.min(index, ratings.length - 1)];
 
- 
-
     if (index >= length) {
       return html`
         <div class="panel-item">
@@ -151,7 +161,8 @@ export class RankingChat extends MobxLitElement {
     const index = this.chatService.getCurrentRatingIndex();
     const length = getChatRatingsToDiscuss(this.stage!).length;
     const readyToEnd = this.experimentService.getParticipantReadyToEndChat(
-      this.stage!.name, this.participantService.profile!.publicId,
+      this.stage!.name,
+      this.participantService.profile!.publicId
     );
 
     return html`
@@ -159,14 +170,110 @@ export class RankingChat extends MobxLitElement {
         <pr-button
           color="tertiary"
           variant="tonal"
-          ?disabled=${readyToEnd || (index >= length)}
+          ?disabled=${readyToEnd || index >= length}
           @click=${() => {
-            this.chatService.markReadyToEndChat(true); }}
+            this.chatService.markReadyToEndChat(true);
+          }}
         >
           Ready to end discussion
         </pr-button>
-        <div>You can still participate in the chat. When everyone is ready to end the discussion, the conversation will progress to the next stage.</div>
+        <div>
+          You can still participate in the chat. When everyone is ready to end
+          the discussion, the conversation will progress to the next stage.
+        </div>
         <progress-end-chat .stageId=${this.stage!.id}></progress-end-chat>
+      </div>
+    `;
+  }
+
+  private renderMediationButton() {
+    if (!this.authService.isExperimenter) {
+      return nothing;
+    }
+
+    const onClick = () => {
+      this.showMediationPanel = !this.showMediationPanel;
+    };
+
+    return html`
+      <div class="panel-item">
+        <div class="panel-item-title">Mediation</div>
+        <pr-button variant="tonal" @click=${onClick}>
+          ${this.showMediationPanel ? 'Hide' : 'Show'} mediation panel
+        </pr-button>
+        <div>This option is visible only to experimenters!</div>
+      </div>
+    `;
+  }
+
+  private renderMediationPanel() {
+    if (!this.authService.isExperimenter || !this.showMediationPanel) {
+      return nothing;
+    }
+
+    const onSendLLMMessage = () => {
+      this.chatService.sendLLMMediatorMessage(this.mediator);
+    };
+
+    return html`
+      <div class="mediation-panel-wrapper">
+        <div class="mediation-panel">
+          <mediator-config .mediator=${this.mediator} .showKind=${false}>
+          </mediator-config>
+          <pr-button @click=${onSendLLMMessage}>
+            Send LLM-generated message
+          </pr-button>
+        </div>
+        ${this.renderMediationInput()}
+      </div>
+    `;
+  }
+
+  private renderMediationInput() {
+    const sendUserInput = () => {
+      this.chatService.sendMediatorMessage(
+        this.value,
+        this.mediator.name,
+        this.mediator.avatar
+      );
+      this.value = '';
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        sendUserInput();
+        e.stopPropagation();
+      }
+    };
+
+    const handleInput = (e: Event) => {
+      this.value = (e.target as HTMLTextAreaElement).value;
+    };
+
+    return html`
+      <div class="mediation-input">
+        <pr-textarea
+          size="small"
+          placeholder="Send message"
+          .value=${this.value}
+          @keyup=${handleKeyUp}
+          @input=${handleInput}
+        >
+        </pr-textarea>
+        <pr-tooltip
+          text="Send mediator message"
+          color="secondary"
+          variant="outlined"
+          position="TOP_RIGHT"
+        >
+          <pr-icon-button
+            icon="send"
+            color="secondary"
+            variant="tonal"
+            @click=${sendUserInput}
+          >
+          </pr-icon-button>
+        </pr-tooltip>
       </div>
     `;
   }
@@ -174,6 +281,6 @@ export class RankingChat extends MobxLitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "lost-at-sea-chat": RankingChat;
+    'lost-at-sea-chat': RankingChat;
   }
 }

--- a/lit/src/experiment-components/election/election_preview.scss
+++ b/lit/src/experiment-components/election/election_preview.scss
@@ -30,6 +30,7 @@
   border-radius: common.$spacing-medium;
   gap: common.$spacing-medium;
   justify-content: space-between;
+  overflow: hidden;
   padding: common.$spacing-medium;
 }
 
@@ -71,10 +72,22 @@
 
 .end-zone {
   @include common.flex-column;
-  gap: common.$spacing-xl;
   background: var(--md-sys-color-surface);
   border: 1px dashed var(--md-sys-color-outline);
   border-radius: common.$spacing-medium;
   min-height: 200px;
   padding: common.$spacing-xl;
+}
+
+.drag-zone{
+  padding: common.$spacing-medium;
+
+  &.drag-over {
+    height: 80px;
+    transition: height .25s ease-out;
+  }
+
+  &.fill {
+    flex-grow: 1;
+  }
 }

--- a/lit/src/experiment-components/election/election_preview.scss
+++ b/lit/src/experiment-components/election/election_preview.scss
@@ -15,12 +15,25 @@
 }
 
 .election-wrapper {
-  @include common.flex-column;
+  display: grid;
   flex-grow: 1;
+  grid-template-columns: repeat(2, 1fr);
   gap: common.$spacing-xxl;
+  width: 100%;
 }
 
-.question-header {
+.draggable,
+.ranked {
+  @include common.flex-row;
+  background: var(--md-sys-color-surface-variant);
+  border: 1px solid var(--md-sys-color-outline);
+  border-radius: common.$spacing-medium;
+  gap: common.$spacing-medium;
+  justify-content: space-between;
+  padding: common.$spacing-medium;
+}
+
+.participant {
   @include common.flex-row-align-center;
   flex-wrap: wrap;
   gap: common.$spacing-large;
@@ -40,19 +53,28 @@
   color: var(--md-sys-color-outline);
 }
 
-.radio-question {
+.zone-header {
   @include common.flex-column;
-  gap: common.$spacing-medium;
+  gap: common.$spacing-small;
+
+  .subtitle {
+    @include typescale.label-small;
+    color: var(--md-sys-color-outline);
+    font-style: italic;
+  }
 }
 
-.radio-buttons-wrapper {
-  @include common.flex-row;
-  flex-wrap: wrap;
-  gap: common.$spacing-xxl;
+.start-zone {
+  @include common.flex-column;
+  gap: common.$spacing-large;
 }
 
-.radio-button {
-  @include common.flex-row-align-center;
-  gap: common.$spacing-medium;
-  min-height: calc(var(--md-sys-typescale-body-small-line-height) * 1.5);
+.end-zone {
+  @include common.flex-column;
+  gap: common.$spacing-xl;
+  background: var(--md-sys-color-surface);
+  border: 1px dashed var(--md-sys-color-outline);
+  border-radius: common.$spacing-medium;
+  min-height: 200px;
+  padding: common.$spacing-xl;
 }

--- a/lit/src/experiment-components/election/election_preview.ts
+++ b/lit/src/experiment-components/election/election_preview.ts
@@ -1,30 +1,31 @@
-import "../footer/footer";
-import "../profile/profile_avatar";
-import "../progress/progress_stage_completed";
-import "../progress/progress_stage_waiting";
+import '../footer/footer';
+import '../profile/profile_avatar';
+import '../progress/progress_stage_completed';
+import '../progress/progress_stage_waiting';
 
 import '@material/web/radio/radio.js';
 
-import { MobxLitElement } from "@adobe/lit-mobx";
-import { CSSResultGroup, html, nothing } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
 
 import {
   ParticipantProfile,
   Vote,
   VoteForLeaderStageAnswer,
-  Votes
-} from "@llm-mediation-experiments/utils";
+  Votes,
+} from '@llm-mediation-experiments/utils';
 
-import { core } from "../../core/core";
-import { ExperimentService } from "../../services/experiment_service";
-import { ParticipantService } from "../../services/participant_service";
-import { RouterService } from "../../services/router_service";
-
-import { styles } from "./election_preview.scss";
+import {unsafeHTML} from 'lit/directives/unsafe-html.js';
+import {core} from '../../core/core';
+import {ExperimentService} from '../../services/experiment_service';
+import {ParticipantService} from '../../services/participant_service';
+import {RouterService} from '../../services/router_service';
+import {convertMarkdownToHTML} from '../../shared/utils';
+import {styles} from './election_preview.scss';
 
 /** Election preview */
-@customElement("election-preview")
+@customElement('election-preview')
 export class ElectionPreview extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
@@ -32,15 +33,20 @@ export class ElectionPreview extends MobxLitElement {
   private readonly participantService = core.getService(ParticipantService);
   private readonly routerService = core.getService(RouterService);
 
-  @property() answer: VoteForLeaderStageAnswer|null = null;
+  @property() answer: VoteForLeaderStageAnswer | null = null;
 
   override render() {
-    const currentStage = this.routerService.activeRoute.params["stage"];
-    const { ready, notReady } =
+    const currentStage = this.routerService.activeRoute.params['stage'];
+    const {ready, notReady} =
       this.experimentService.getParticipantsReadyForStage(currentStage);
 
-    const description = this.experimentService.stageConfigMap[currentStage].description;
-    const descriptionContent = description ? html`<div class="description">${description}</div>` : nothing;
+    const description =
+      this.experimentService.stageConfigMap[currentStage].description;
+    const descriptionContent = description
+      ? html`<div class="description">
+          ${unsafeHTML(convertMarkdownToHTML(description))}
+        </div>`
+      : nothing;
     if (notReady.length > 0) {
       return html`
         ${descriptionContent}
@@ -50,16 +56,18 @@ export class ElectionPreview extends MobxLitElement {
       `;
     }
 
-    const disabled = Object.keys(this.answer?.votes ?? []).length <
+    const disabled =
+      Object.keys(this.answer?.votes ?? []).length <
       this.experimentService.getParticipantProfiles().length - 1;
 
     return html`
       ${descriptionContent}
 
       <div class="election-wrapper">
-        ${this.experimentService.getParticipantProfiles()
+        ${this.experimentService
+          .getParticipantProfiles()
           .sort((p1, p2) => p1.publicId.localeCompare(p2.publicId))
-          .map(profile => this.renderParticipant(profile))}
+          .map((profile) => this.renderParticipant(profile))}
       </div>
       <stage-footer .disabled=${disabled}>
         <progress-stage-completed></progress-stage-completed>
@@ -74,11 +82,11 @@ export class ElectionPreview extends MobxLitElement {
 
     const getVoteFromValue = (value: string) => {
       switch (value) {
-        case "0":
+        case '0':
           return Vote.Positive;
-        case "1":
+        case '1':
           return Vote.Neutral;
-        case "2":
+        case '2':
           return Vote.Negative;
         default:
           return Vote.NotRated;
@@ -94,7 +102,7 @@ export class ElectionPreview extends MobxLitElement {
       this.participantService.updateVoteForLeaderStage(
         this.participantService.profile!.currentStageId,
         votes
-      )
+      );
     };
 
     return html`
@@ -114,7 +122,7 @@ export class ElectionPreview extends MobxLitElement {
               name=${profile.publicId}
               value="0"
               aria-label="positive"
-              ?checked=${this.answer?.votes[profile.publicId] === "positive"}
+              ?checked=${this.answer?.votes[profile.publicId] === 'positive'}
               ?disabled=${!this.participantService.isCurrentStage()}
               @change=${handleClick}
             >
@@ -127,7 +135,7 @@ export class ElectionPreview extends MobxLitElement {
               name=${profile.publicId}
               value="1"
               aria-label="neutral"
-              ?checked=${this.answer?.votes[profile.publicId] === "neutral"}
+              ?checked=${this.answer?.votes[profile.publicId] === 'neutral'}
               ?disabled=${!this.participantService.isCurrentStage()}
               @change=${handleClick}
             >
@@ -140,7 +148,7 @@ export class ElectionPreview extends MobxLitElement {
               name=${profile.publicId}
               value="2"
               aria-label="negative"
-              ?checked=${this.answer?.votes[profile.publicId] === "negative"}
+              ?checked=${this.answer?.votes[profile.publicId] === 'negative'}
               ?disabled=${!this.participantService.isCurrentStage()}
               @change=${handleClick}
             >
@@ -153,7 +161,7 @@ export class ElectionPreview extends MobxLitElement {
               name=${profile.publicId}
               value="3"
               aria-label="no rating"
-              ?checked=${this.answer?.votes[profile.publicId] === "not-rated"}
+              ?checked=${this.answer?.votes[profile.publicId] === 'not-rated'}
               ?disabled=${!this.participantService.isCurrentStage()}
               @change=${handleClick}
             >
@@ -168,6 +176,6 @@ export class ElectionPreview extends MobxLitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "election-preview": ElectionPreview;
+    'election-preview': ElectionPreview;
   }
 }

--- a/lit/src/experiment-components/election/election_preview.ts
+++ b/lit/src/experiment-components/election/election_preview.ts
@@ -129,7 +129,7 @@ export class ElectionPreview extends MobxLitElement {
     return html`
       <div
         class="draggable"
-        draggable="true"
+        draggable=${this.participantService.isCurrentStage()}
         .ondragstart=${onDragStart}
         .ondragend=${onDragEnd}
       >
@@ -244,7 +244,7 @@ export class ElectionPreview extends MobxLitElement {
       ${this.renderDragZone(index)}
       <div
         class="ranked"
-        draggable="true"
+        draggable=${this.participantService.isCurrentStage()}
         .ondragstart=${onDragStart}
         .ondragend=${onDragEnd}
       >
@@ -253,6 +253,7 @@ export class ElectionPreview extends MobxLitElement {
           icon="close"
           color="neutral"
           variant="default"
+          ?disabled=${!this.participantService.isCurrentStage()}
           @click=${onCancel}
         >
         </pr-icon-button>

--- a/lit/src/experiment-components/election/election_preview.ts
+++ b/lit/src/experiment-components/election/election_preview.ts
@@ -1,13 +1,13 @@
+import '../../pair-components/icon_button';
+
 import '../footer/footer';
 import '../profile/profile_avatar';
 import '../progress/progress_stage_completed';
 import '../progress/progress_stage_waiting';
 
-import '@material/web/radio/radio.js';
-
 import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
+import {customElement, property, state} from 'lit/decorators.js';
 
 import {
   ParticipantProfile,
@@ -37,41 +37,55 @@ export class ElectionPreview extends MobxLitElement {
 
   override render() {
     const currentStage = this.routerService.activeRoute.params['stage'];
+    if (!currentStage) {
+      return nothing;
+    }
+
     const {ready, notReady} =
       this.experimentService.getParticipantsReadyForStage(currentStage);
 
     const description =
       this.experimentService.stageConfigMap[currentStage].description;
+
     const descriptionContent = description
       ? html`<div class="description">
           ${unsafeHTML(convertMarkdownToHTML(description))}
         </div>`
       : nothing;
+
     if (notReady.length > 0) {
       return html`
         ${descriptionContent}
-
         <progress-stage-waiting .stageId=${currentStage}>
         </progress-stage-waiting>
       `;
     }
 
-    const disabled =
-      Object.keys(this.answer?.votes ?? []).length <
+    const disabled = (this.answer?.rankings ?? []).length <
       this.experimentService.getParticipantProfiles().length - 1;
 
     return html`
       ${descriptionContent}
 
       <div class="election-wrapper">
-        ${this.experimentService
-          .getParticipantProfiles()
-          .sort((p1, p2) => p1.publicId.localeCompare(p2.publicId))
-          .map((profile) => this.renderParticipant(profile))}
+        ${this.renderStartZone()}
+        ${this.renderEndZone()}
       </div>
       <stage-footer .disabled=${disabled}>
         <progress-stage-completed></progress-stage-completed>
       </stage-footer>
+    `;
+  }
+
+  private renderStartZone() {
+    return html`
+      <div class="start-zone">
+        ${this.experimentService
+          .getParticipantProfiles()
+          .sort((p1, p2) => p1.publicId.localeCompare(p2.publicId))
+          .filter((profile) => !(this.answer?.rankings ?? []).find(id => id === profile.publicId))
+          .map((profile) => this.renderDraggableParticipant(profile))}
+      </div>
     `;
   }
 
@@ -80,95 +94,115 @@ export class ElectionPreview extends MobxLitElement {
       return nothing;
     }
 
-    const getVoteFromValue = (value: string) => {
-      switch (value) {
-        case '0':
-          return Vote.Positive;
-        case '1':
-          return Vote.Neutral;
-        case '2':
-          return Vote.Negative;
-        default:
-          return Vote.NotRated;
+    return html`
+      <div class="participant">
+        <profile-avatar .emoji=${profile.avatarUrl} .square=${true}>
+        </profile-avatar>
+        <div class="right">
+          <div class="title">${profile.name}</div>
+          <div class="subtitle">(${profile.pronouns})</div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderDraggableParticipant(profile: ParticipantProfile) {
+    if (profile.publicId === this.participantService.profile?.publicId) {
+      return nothing;
+    }
+
+    const onDragStart = (event: DragEvent) => {
+      let target = (event.target as HTMLElement);
+      if (event.dataTransfer) {
+        event.dataTransfer.effectAllowed = "move";
+        event.dataTransfer.setData('text/plain', profile.publicId);
       }
     };
 
-    const handleClick = (e: Event) => {
-      const value = (e.target as HTMLInputElement).value;
+    return html`
+      <div
+        class="draggable"
+        draggable="true"
+        .ondragstart=${onDragStart}
+      >
+        ${this.renderParticipant(profile)}
+      </div>
+    `;
+  }
 
-      const votes: Votes = {};
-      votes[profile.publicId] = getVoteFromValue(value);
+  private renderRankedParticipant(profile: ParticipantProfile) {
+    if (profile.publicId === this.participantService.profile?.publicId) {
+      return nothing;
+    }
+
+    const onCancel = () => {
+      const stageId = this.routerService.activeRoute.params['stage'];
+      const rankings = this.answer?.rankings ?? [];
+      const index = rankings.findIndex(id => id === profile.publicId);
 
       this.participantService.updateVoteForLeaderStage(
-        this.participantService.profile!.currentStageId,
-        votes
+        stageId,
+        [...rankings.slice(0, index), ...rankings.slice(index + 1)]
       );
     };
 
     return html`
-      <div class="radio-question">
-        <div class="question-header">
-          <profile-avatar .emoji=${profile.avatarUrl} .square=${true}>
-          </profile-avatar>
-          <div class="right">
-            <div class="title">${profile.name}</div>
-            <div class="subtitle">(${profile.pronouns})</div>
+      <div class="ranked">
+        ${this.renderParticipant(profile)}
+        <pr-icon-button
+          icon="close"
+          color="neutral"
+          variant="default"
+          @click=${onCancel}
+        >
+        </pr-icon-button>
+      </div>
+    `;
+  }
+
+  private renderEndZone() {
+    const onDragEnter = (event: DragEvent) => {
+      const target = (event.target as HTMLElement);
+      if (target && event.dataTransfer) {
+        event.preventDefault();
+        event.dataTransfer.dropEffect = 'move';
+      }
+    }
+
+    const onDrop = (event: DragEvent) => {
+      const target = (event.target as HTMLElement);
+      if (target && event.dataTransfer) {
+        event.preventDefault();
+        const stageId = this.routerService.activeRoute.params['stage'];
+        this.participantService.updateVoteForLeaderStage(
+          stageId,
+          [...this.answer?.rankings ?? [], event.dataTransfer.getData('text/plain')]
+        );
+      }
+    };
+
+    const onDragOver = (event: DragEvent) => {
+      event.preventDefault();
+    };
+
+    return html`
+      <div class="end-zone"
+        .ondragover=${onDragOver}
+        .ondragenter=${onDragEnter}
+        .ondrop=${onDrop}
+      >
+        <div class="zone-header">
+          <div class="title">Leader rankings</div>
+          <div class="subtitle">
+            Drag and drop to rank participants (with most preferred at top)
           </div>
         </div>
-        <div class="radio-buttons-wrapper">
-          <div class="radio-button">
-            <md-radio
-              id="positive"
-              name=${profile.publicId}
-              value="0"
-              aria-label="positive"
-              ?checked=${this.answer?.votes[profile.publicId] === 'positive'}
-              ?disabled=${!this.participantService.isCurrentStage()}
-              @change=${handleClick}
-            >
-            </md-radio>
-            <label>positive</label>
-          </div>
-          <div class="radio-button">
-            <md-radio
-              id="neutral"
-              name=${profile.publicId}
-              value="1"
-              aria-label="neutral"
-              ?checked=${this.answer?.votes[profile.publicId] === 'neutral'}
-              ?disabled=${!this.participantService.isCurrentStage()}
-              @change=${handleClick}
-            >
-            </md-radio>
-            <label>neutral</label>
-          </div>
-          <div class="radio-button">
-            <md-radio
-              id="negative"
-              name=${profile.publicId}
-              value="2"
-              aria-label="negative"
-              ?checked=${this.answer?.votes[profile.publicId] === 'negative'}
-              ?disabled=${!this.participantService.isCurrentStage()}
-              @change=${handleClick}
-            >
-            </md-radio>
-            <label>negative</label>
-          </div>
-          <div class="radio-button">
-            <md-radio
-              id="none"
-              name=${profile.publicId}
-              value="3"
-              aria-label="no rating"
-              ?checked=${this.answer?.votes[profile.publicId] === 'not-rated'}
-              ?disabled=${!this.participantService.isCurrentStage()}
-              @change=${handleClick}
-            >
-            </md-radio>
-            <label>no rating</label>
-          </div>
-        </div>
+        ${this.answer?.rankings.map((publicId: string) => {
+          const participant = this.experimentService.getParticipantProfiles()
+            .find(profile => profile.publicId === publicId);
+
+          return participant ? this.renderRankedParticipant(participant) : nothing;
+        })}
       </div>
     `;
   }

--- a/lit/src/experiment-components/election/election_preview.ts
+++ b/lit/src/experiment-components/election/election_preview.ts
@@ -7,13 +7,11 @@ import '../progress/progress_stage_waiting';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
-import {customElement, property, state} from 'lit/decorators.js';
+import {customElement, property} from 'lit/decorators.js';
 
 import {
   ParticipantProfile,
-  Vote,
   VoteForLeaderStageAnswer,
-  Votes,
 } from '@llm-mediation-experiments/utils';
 
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
@@ -61,15 +59,15 @@ export class ElectionPreview extends MobxLitElement {
       `;
     }
 
-    const disabled = (this.answer?.rankings ?? []).length <
+    const disabled =
+      (this.answer?.rankings ?? []).length <
       this.experimentService.getParticipantProfiles().length - 1;
 
     return html`
       ${descriptionContent}
 
       <div class="election-wrapper">
-        ${this.renderStartZone()}
-        ${this.renderEndZone()}
+        ${this.renderStartZone()} ${this.renderEndZone()}
       </div>
       <stage-footer .disabled=${disabled}>
         <progress-stage-completed></progress-stage-completed>
@@ -83,7 +81,12 @@ export class ElectionPreview extends MobxLitElement {
         ${this.experimentService
           .getParticipantProfiles()
           .sort((p1, p2) => p1.publicId.localeCompare(p2.publicId))
-          .filter((profile) => !(this.answer?.rankings ?? []).find(id => id === profile.publicId))
+          .filter(
+            (profile) =>
+              !(this.answer?.rankings ?? []).find(
+                (id) => id === profile.publicId
+              )
+          )
           .map((profile) => this.renderDraggableParticipant(profile))}
       </div>
     `;
@@ -112,17 +115,17 @@ export class ElectionPreview extends MobxLitElement {
     }
 
     const onDragStart = (event: DragEvent) => {
-      let target = (event.target as HTMLElement);
+      let target = event.target as HTMLElement;
       target.style.opacity = '.25';
 
       if (event.dataTransfer) {
-        event.dataTransfer.effectAllowed = "move";
+        event.dataTransfer.effectAllowed = 'move';
         event.dataTransfer.setData('text/plain', profile.publicId);
       }
     };
 
     const onDragEnd = (event: DragEvent) => {
-      let target = (event.target as HTMLElement);
+      let target = event.target as HTMLElement;
       target.style.opacity = '';
     };
 
@@ -140,7 +143,7 @@ export class ElectionPreview extends MobxLitElement {
 
   private renderDragZone(index: number, fillSpace = false) {
     const onDragEnter = (event: DragEvent) => {
-      const target = (event.target as HTMLElement);
+      const target = event.target as HTMLElement;
       if (target && event.dataTransfer) {
         event.preventDefault();
         event.dataTransfer.dropEffect = 'move';
@@ -149,14 +152,14 @@ export class ElectionPreview extends MobxLitElement {
     };
 
     const onDragLeave = (event: DragEvent) => {
-      const target = (event.target as HTMLElement);
+      const target = event.target as HTMLElement;
       if (target) {
         target.classList.remove('drag-over');
       }
     };
 
     const onDrop = (event: DragEvent) => {
-      const target = (event.target as HTMLElement);
+      const target = event.target as HTMLElement;
       if (target && event.dataTransfer) {
         event.preventDefault();
         target.classList.remove('drag-over');
@@ -168,14 +171,16 @@ export class ElectionPreview extends MobxLitElement {
         // Create new rankings (using answerIndex to slot participant in)
         let rankings = [...currentRankings];
 
-        const existingIndex = currentRankings.findIndex(id => id === participantId);
+        const existingIndex = currentRankings.findIndex(
+          (id) => id === participantId
+        );
         let newIndex = index;
 
         if (existingIndex >= 0) {
           // Remove participant from current ranking spot
           rankings = [
             ...rankings.slice(0, existingIndex),
-            ...rankings.slice(existingIndex + 1)
+            ...rankings.slice(existingIndex + 1),
           ];
           if (existingIndex <= newIndex) {
             newIndex -= 1; // Adjust index because participant was removed
@@ -184,13 +189,9 @@ export class ElectionPreview extends MobxLitElement {
         rankings = [
           ...rankings.slice(0, newIndex),
           participantId,
-          ...rankings.slice(newIndex)
+          ...rankings.slice(newIndex),
         ];
-
-        this.participantService.updateVoteForLeaderStage(
-          stageId,
-          rankings
-        );
+        this.participantService.updateVoteForLeaderStage(stageId, rankings);
       }
     };
 
@@ -199,13 +200,13 @@ export class ElectionPreview extends MobxLitElement {
     };
 
     return html`
-      <div class="drag-zone ${fillSpace ? 'fill' : ''}"
+      <div
+        class="drag-zone ${fillSpace ? 'fill' : ''}"
         .ondragover=${onDragOver}
         .ondragenter=${onDragEnter}
         .ondragleave=${onDragLeave}
         .ondrop=${onDrop}
-      >
-      </div>
+      ></div>
     `;
   }
 
@@ -217,26 +218,26 @@ export class ElectionPreview extends MobxLitElement {
     const onCancel = () => {
       const stageId = this.routerService.activeRoute.params['stage'];
       const rankings = this.answer?.rankings ?? [];
-      const index = rankings.findIndex(id => id === profile.publicId);
+      const index = rankings.findIndex((id) => id === profile.publicId);
 
-      this.participantService.updateVoteForLeaderStage(
-        stageId,
-        [...rankings.slice(0, index), ...rankings.slice(index + 1)]
-      );
+      this.participantService.updateVoteForLeaderStage(stageId, [
+        ...rankings.slice(0, index),
+        ...rankings.slice(index + 1),
+      ]);
     };
 
     const onDragStart = (event: DragEvent) => {
-      let target = (event.target as HTMLElement);
+      let target = event.target as HTMLElement;
       target.style.opacity = '.25';
 
       if (event.dataTransfer) {
-        event.dataTransfer.effectAllowed = "move";
+        event.dataTransfer.effectAllowed = 'move';
         event.dataTransfer.setData('text/plain', profile.publicId);
       }
     };
 
     const onDragEnd = (event: DragEvent) => {
-      let target = (event.target as HTMLElement);
+      let target = event.target as HTMLElement;
       target.style.opacity = '';
     };
 
@@ -271,12 +272,15 @@ export class ElectionPreview extends MobxLitElement {
           </div>
         </div>
         ${this.answer?.rankings.map((publicId: string, index: number) => {
-          const participant = this.experimentService.getParticipantProfiles()
-            .find(profile => profile.publicId === publicId);
+          const participant = this.experimentService
+            .getParticipantProfiles()
+            .find((profile) => profile.publicId === publicId);
 
-          return participant ? this.renderRankedParticipant(participant, index) : nothing;
+          return participant
+            ? this.renderRankedParticipant(participant, index)
+            : nothing;
         })}
-      ${this.renderDragZone((this.answer?.rankings ?? []).length, true)}
+        ${this.renderDragZone((this.answer?.rankings ?? []).length, true)}
       </div>
     `;
   }

--- a/lit/src/experiment-components/experiment/experiment_config_menu.ts
+++ b/lit/src/experiment-components/experiment/experiment_config_menu.ts
@@ -105,8 +105,11 @@ export class ExperimentConfigMenu extends MobxLitElement {
     }
 
     const onAddLeaderClick = () => {
-      this.experimentConfig.addStage(createVoteForLeaderStage());
-      this.experimentConfig.addStage(createRevealStage());
+      const voteStage = createVoteForLeaderStage();
+      this.experimentConfig.addStage(voteStage);
+      this.experimentConfig.addStage(
+        createRevealStage({stagesToReveal: [voteStage.id]})
+      );
       this.experimentConfig.setCurrentStageIndexToLast();
     };
 

--- a/lit/src/experiment-components/experiment/experiment_config_metadata.scss
+++ b/lit/src/experiment-components/experiment/experiment_config_metadata.scss
@@ -37,3 +37,7 @@ md-checkbox {
   color: var(--md-sys-color-outline);
   font-style: italic;
 }
+
+.tab {
+  margin-left: 50px;
+}

--- a/lit/src/experiment-components/experiment/experiment_config_metadata.ts
+++ b/lit/src/experiment-components/experiment/experiment_config_metadata.ts
@@ -35,6 +35,7 @@ export class ExperimentConfig extends MobxLitElement {
     return html`
       ${this.renderExperimentDetailFields()} ${this.renderGroupToggle()}
       ${this.renderConstrainParticipantsToggle()} ${this.renderProlificLogic()}
+      ${this.renderAttentionCheckToggle()}
     `;
   }
 
@@ -227,6 +228,102 @@ export class ExperimentConfig extends MobxLitElement {
       <div class="divider"></div>
     `;
   }
+  private renderAttentionCheckToggle() {
+    const handleAddAttentionCheck = (e: Event) => {
+      const checked = Boolean((e.target as HTMLInputElement).checked);
+      if (!checked) {
+        this.experimentConfig.resetAttentionCheck();
+      } else {
+        this.experimentConfig.hasAttentionCheck = checked;
+        this.experimentConfig.waitSeconds = 5 * 60;
+        this.experimentConfig.popupSeconds = 60;
+        this.experimentConfig.prolificAttentionFailRedirectCode = '';
+      }
+    };
+
+    const handleWaitSeconds = (e: Event) => {
+      const num = Number((e.target as HTMLTextAreaElement).value);
+      this.experimentConfig.updateWaitSeconds(num);
+    };
+
+    const handlePopupSeconds = (e: Event) => {
+      const num = Number((e.target as HTMLTextAreaElement).value);
+      this.experimentConfig.updatePopupSeconds(num);
+    };
+
+    const handleProlificFailure = (e: Event) => {
+      const value = (e.target as HTMLTextAreaElement).value;
+      this.experimentConfig.updateProlificFailCode(value);
+    };
+
+    return html`
+      <h2>👀 Attention check parameters</h2>
+      <div class="checkbox-input-container">
+        <div class="checkbox-input">
+          <md-checkbox
+            id="hasAttentionCheck"
+            touch-target="wrapper"
+            .checked=${this.experimentConfig.hasAttentionCheck}
+            @change=${handleAddAttentionCheck}
+          ></md-checkbox>
+          <label for="hasAttentionCheck">
+            <div>
+              Enable attention checks
+              <div class="subtitle">
+                Times out the participant from the experiment if the attention
+                check prompt is not clicked within the given time.
+              </div>
+            </div>
+          </label>
+        </div>
+      </div>
+
+      ${this.experimentConfig.hasAttentionCheck
+        ? html`
+            <div class="number-input tab">
+              <label for="num"
+                >Wait time (in seconds) before attention check popup</label
+              >
+              <input
+                type="number"
+                id="waitSeconds"
+                name="waitSeconds"
+                min="1"
+                .value=${this.experimentConfig.waitSeconds}
+                @input=${handleWaitSeconds}
+              />
+            </div>
+
+            <div class="number-input tab">
+              <label for="num">Popup display time (in seconds)</label>
+              <input
+                type="number"
+                id="popupSeconds"
+                name="popupSeconds"
+                min="1"
+                .value=${this.experimentConfig.popupSeconds}
+                @input=${handlePopupSeconds}
+              />
+            </div>
+            ${this.experimentConfig.isProlific
+              ? html`
+                  <pr-textarea
+                    class="tab"
+                    label="Prolific failure code (optional)"
+                    placeholder="This code will be sent to Prolific if the attention check fails"
+                    variant="outlined"
+                    .value=${this.experimentConfig
+                      .prolificAttentionFailRedirectCode}
+                    @input=${handleProlificFailure}
+                  >
+                  </pr-textarea>
+                `
+              : ''}
+          `
+        : ''}
+      <div class="divider"></div>
+    `;
+  }
 
   private renderProlificCodeField() {
     const handleCode = (e: Event) => {
@@ -236,6 +333,7 @@ export class ExperimentConfig extends MobxLitElement {
 
     return html`
       <pr-textarea
+        class="tab"
         label="Prolific completion code"
         placeholder="This code will redirect participants to Prolific"
         variant="outlined"

--- a/lit/src/experiment-components/experiment/experiment_config_metadata.ts
+++ b/lit/src/experiment-components/experiment/experiment_config_metadata.ts
@@ -1,24 +1,24 @@
-import "../../pair-components/button";
-import "../../pair-components/icon_button";
-import "../../pair-components/textarea";
-import "../../pair-components/tooltip";
+import '../../pair-components/button';
+import '../../pair-components/icon_button';
+import '../../pair-components/textarea';
+import '../../pair-components/tooltip';
 
-import "@material/web/checkbox/checkbox.js";
+import '@material/web/checkbox/checkbox.js';
 
-import { MobxLitElement } from "@adobe/lit-mobx";
-import { CSSResultGroup, html, nothing } from "lit";
-import { customElement } from "lit/decorators.js";
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement} from 'lit/decorators.js';
 
-import { core } from "../../core/core";
-import { AuthService } from "../../services/auth_service";
-import { ExperimentConfigService } from "../../services/config/experiment_config_service";
-import { RouterService } from "../../services/router_service";
+import {core} from '../../core/core';
+import {AuthService} from '../../services/auth_service';
+import {ExperimentConfigService} from '../../services/config/experiment_config_service';
+import {RouterService} from '../../services/router_service';
 
-import { ExperimenterService } from "../../services/experimenter_service";
-import { styles } from "./experiment_config_metadata.scss";
+import {ExperimenterService} from '../../services/experimenter_service';
+import {styles} from './experiment_config_metadata.scss';
 
 /** Metadata for experiment config page */
-@customElement("experiment-config-metadata")
+@customElement('experiment-config-metadata')
 export class ExperimentConfig extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
@@ -33,24 +33,27 @@ export class ExperimentConfig extends MobxLitElement {
     }
 
     return html`
-      ${this.renderGroupToggle()}
-      ${this.renderNameFields()}
-      ${this.renderDescriptionField()}
-      ${this.renderProlificLogic()}
-      ${this.renderConstrainParticipantsToggle()}
-      ${this.renderGroupConfig()}
+      ${this.renderExperimentDetailFields()} ${this.renderGroupToggle()}
+      ${this.renderConstrainParticipantsToggle()} ${this.renderProlificLogic()}
     `;
   }
 
+  private renderExperimentDetailFields() {
+    return html`
+      <h2>📕 Metadata</h2>
+      ${this.renderNameFields()} ${this.renderDescriptionField()}
+      <div class="divider"></div>
+    `;
+  }
   private renderDescriptionField() {
     const handleDescription = (e: Event) => {
       const value = (e.target as HTMLTextAreaElement).value;
       this.experimentConfig.updateDescription(value);
-    }
+    };
 
     return html`
       <pr-textarea
-        label="Private experiment description"
+        label="Internal experiment description"
         placeholder="This description is only visible to experimenters"
         variant="outlined"
         .value=${this.experimentConfig.description}
@@ -67,12 +70,12 @@ export class ExperimentConfig extends MobxLitElement {
     };
 
     return html`
-      <div class="number-input">
-        <label for="num">Maximum number of participants</label>
+      <div class="number-input tab">
+        <label for="num">Maximum participants</label>
         <input
           type="number"
           id="num"
-          name="numParticipants"
+          njkime="numParticipants"
           min="0"
           placeholder="Leave this blank if there is no threshold"
           .value=${this.experimentConfig.numMaxParticipants}
@@ -95,30 +98,30 @@ export class ExperimentConfig extends MobxLitElement {
 
     const getExperimentNameLabel = () => {
       if (this.experimentConfig.isGroup) {
-        return "Experiment group name (private)*";
+        return 'Internal experiment group name*';
       }
-      return "Experiment name (private)*";
-    }
+      return 'Internal experiment name*';
+    };
 
     return html`
       <pr-textarea
-        label=${getExperimentNameLabel()}
-        placeholder="Internal experiment name"}
-        variant="outlined"
-        class="required"
-        .value=${this.experimentConfig.name}
-        @input=${handleName}
-      >
-      </pr-textarea>
-      <pr-textarea
-        label="Public-facing experiment name (visible to participants)"
+        label="Public experiment name (visible to participants)"
         placeholder="Public experiment name"
         variant="outlined"
         .value=${this.experimentConfig.publicName}
         @input=${handlePublicName}
       >
       </pr-textarea>
-
+      <pr-textarea
+        label=${getExperimentNameLabel()}
+        placeholder="Internal experiment name"
+        }
+        variant="outlined"
+        class="required"
+        .value=${this.experimentConfig.name}
+        @input=${handleName}
+      >
+      </pr-textarea>
     `;
   }
 
@@ -129,21 +132,29 @@ export class ExperimentConfig extends MobxLitElement {
     };
 
     return html`
+      <h2>📚 Experiment group configuration</h2>
+
       <div class="checkbox-input-container">
         <div class="checkbox-input">
-          <md-checkbox id="isExperimentGroup" touch-target="wrapper"
+          <md-checkbox
+            id="isExperimentGroup"
+            touch-target="wrapper"
             .checked=${this.experimentConfig.isGroup}
             @change=${handleGroupCheckbox}
           ></md-checkbox>
           <label for="isExperimentGroup">
-            <div>Create a group of experiments</div>
-            <div class="subtitle">The experiment group options allow you to create a group of experiments with the same configuration.</div>
+            <div>Create experiment group</div>
+            <div class="subtitle">
+              Create a group of experiments with identical settings.
+            </div>
           </label>
         </div>
       </div>
+      ${this.experimentConfig.isGroup ? this.renderGroupConfig() : ''}
+      <div class="divider"></div>
     `;
   }
-   
+
   private renderConstrainParticipantsToggle() {
     const handleConstrainToggle = (e: Event) => {
       const checked = Boolean((e.target as HTMLInputElement).checked);
@@ -154,23 +165,32 @@ export class ExperimentConfig extends MobxLitElement {
     };
 
     return html`
+      <h2>👥 Participant management</h2>
       <div class="checkbox-input-container">
         <div class="checkbox-input">
-          <md-checkbox id="constrainMaxParticipants" touch-target="wrapper"
+          <md-checkbox
+            id="constrainMaxParticipants"
+            touch-target="wrapper"
             .checked=${this.experimentConfig.hasMaxNumParticipants}
             @change=${handleConstrainToggle}
           ></md-checkbox>
           <label for="constrainMaxParticipants">
-            <div>Limit the number of participants</div>
+            <div>Limit participant enrollment</div>
+            <div class="subtitle">
+              Restrict the total number of participants for the experiment.
+            </div>
           </label>
         </div>
       </div>
-    
-      ${this.experimentConfig.hasMaxNumParticipants ? 
-        html`
-          ${this.renderNumMaxParticipantsField()}
-          ${this.renderWaitForAllToStartToggle()}
-        `: ''}
+
+      ${this.experimentConfig.hasMaxNumParticipants
+        ? html`
+            ${this.renderNumMaxParticipantsField()}
+            ${this.renderWaitForAllToStartToggle()}
+          `
+        : ''}
+
+      <div class="divider"></div>
     `;
   }
 
@@ -181,40 +201,49 @@ export class ExperimentConfig extends MobxLitElement {
     };
 
     return html`
+      <h2>🌅 Prolific integration</h2>
       <div class="checkbox-input-container">
         <div class="checkbox-input">
-          <md-checkbox id="isProlific" touch-target="wrapper"
+          <md-checkbox
+            id="isProlific"
+            touch-target="wrapper"
             .checked=${this.experimentConfig.isProlific}
             @change=${handleIsProlific}
           ></md-checkbox>
           <label for="waitForAll">
-            <div>${this.experimentConfig.isGroup ? 'These experiments are' : 'This experiment is'} hosted on Prolific 🌅</div>
+            <div>
+              Host on Prolific
+              <div class="subtitle">
+                Enable integration with Prolific for this experiment.
+              </div>
+            </div>
           </label>
         </div>
       </div>
 
-      ${this.experimentConfig.isProlific ?
-      html`
-      ${this.renderProlificCodeField()}` : ''}
+      ${this.experimentConfig.isProlific
+        ? html` ${this.renderProlificCodeField()}`
+        : ''}
+      <div class="divider"></div>
     `;
   }
 
   private renderProlificCodeField() {
-      const handleCode = (e: Event) => {
-        const value = (e.target as HTMLTextAreaElement).value;
-        this.experimentConfig.updateProlificRedirectCode(value);
-      }
-  
-      return html`
-        <pr-textarea
-          label="Prolific completion code"
-          placeholder="This code will redirect participants to Prolific"
-          variant="outlined"
-          .value=${this.experimentConfig.prolificRedirectCode}
-          @input=${handleCode}
-        >
-        </pr-textarea>
-      `;
+    const handleCode = (e: Event) => {
+      const value = (e.target as HTMLTextAreaElement).value;
+      this.experimentConfig.updateProlificRedirectCode(value);
+    };
+
+    return html`
+      <pr-textarea
+        label="Prolific completion code"
+        placeholder="This code will redirect participants to Prolific"
+        variant="outlined"
+        .value=${this.experimentConfig.prolificRedirectCode}
+        @input=${handleCode}
+      >
+      </pr-textarea>
+    `;
   }
 
   private renderWaitForAllToStartToggle() {
@@ -226,12 +255,18 @@ export class ExperimentConfig extends MobxLitElement {
     return html`
       <div class="checkbox-input-container">
         <div class="checkbox-input">
-          <md-checkbox id="waitForAll" touch-target="wrapper"
+          <md-checkbox
+            id="waitForAll"
+            touch-target="wrapper"
             .checked=${this.experimentConfig.waitForAllToStart}
             @change=${handleStartToggle}
           ></md-checkbox>
           <label for="waitForAll">
-            <div>Wait for all participants to join before allowing the experiment to start</div>
+            <div>Wait for full enrollment</div>
+            <div class="subtitle">
+              Ensure the experiment starts only when all participants have
+              joined.
+            </div>
           </label>
         </div>
       </div>
@@ -239,10 +274,6 @@ export class ExperimentConfig extends MobxLitElement {
   }
 
   private renderGroupConfig() {
-    if (!this.experimentConfig.isGroup) {
-      return nothing;
-    }
-
     const handleGroupNum = (e: Event) => {
       const num = Number((e.target as HTMLTextAreaElement).value);
       this.experimentConfig.updateNumExperiments(num);
@@ -254,10 +285,8 @@ export class ExperimentConfig extends MobxLitElement {
     };
 
     return html`
-      <div class="divider"></div>
-      <h2>Group-specific settings</h2>
-      <div class="number-input">
-        <label for="num">Number of experiments</label>
+      <div class="number-input tab">
+        <label for="num">Number of experiments in group</label>
         <input
           type="number"
           id="numExperiments"
@@ -268,14 +297,17 @@ export class ExperimentConfig extends MobxLitElement {
         />
       </div>
       <div class="checkbox-input">
-        <md-checkbox id="isExperimentGroup" touch-target="wrapper"
+        <md-checkbox
+          id="isExperimentGroup"
+          touch-target="wrapper"
           .checked=${this.experimentConfig.isMultiPart}
           @change=${handleMultiPartCheckbox}
         ></md-checkbox>
         <label for="isExperimentGroup">
-          <div>Create a muti-part experiment</div>
+          <div>Create muti-part experiment</div>
           <div class="subtitle">
-            This will add a "lobby" stage; move the stage to divide your experiment into two parts. A lobby experiment will be created for the first part. You can redirect people to the second experiment.
+            Add a "lobby" stage to divide your experiment into two parts. You
+            can redirect people to the second part of the experiment.
           </div>
         </label>
       </div>
@@ -285,6 +317,6 @@ export class ExperimentConfig extends MobxLitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "experiment-config-metadata": ExperimentConfig;
+    'experiment-config-metadata': ExperimentConfig;
   }
 }

--- a/lit/src/experiment-components/experiment/experiment_preview.ts
+++ b/lit/src/experiment-components/experiment/experiment_preview.ts
@@ -18,6 +18,7 @@ import {ExperimenterService} from '../../services/experimenter_service';
 import {ParticipantService} from '../../services/participant_service';
 import {Pages, RouterService} from '../../services/router_service';
 
+import {PARTICIPANT_COMPLETION_TYPE} from '@llm-mediation-experiments/utils';
 import {styles} from './experiment_preview.scss';
 
 /** Experiment preview */
@@ -108,14 +109,21 @@ export class ExperimentPreview extends MobxLitElement {
     );
     const timedOutParticipants = participants.filter(
       (participant) =>
-        this.experimentService.experiment?.isLobby &&
-        participant.completedExperiment &&
-        !participant.transferConfig
+        participant.completionType ===
+          PARTICIPANT_COMPLETION_TYPE.ATTENTION_TIMEOUT ||
+        participant.completionType ===
+          PARTICIPANT_COMPLETION_TYPE.LOBBY_TIMEOUT ||
+        (!participant.completionType &&
+          this.experimentService.experiment?.isLobby &&
+          participant.completedExperiment &&
+          !participant.transferConfig)
     );
     const completedParticipants = participants.filter(
       (participant) =>
-        participant.completedExperiment &&
-        !this.experimentService.experiment?.isLobby
+        participant.completionType === PARTICIPANT_COMPLETION_TYPE.SUCCESS ||
+        (!participant.completionType &&
+          participant.completedExperiment &&
+          !this.experimentService.experiment?.isLobby)
     );
 
     const experiment = this.experimentService.experiment;
@@ -140,8 +148,31 @@ export class ExperimentPreview extends MobxLitElement {
             ${experiment?.prolificRedirectCode
               ? html`
                   Prolific redirect code: ${experiment?.prolificRedirectCode}
+                  ${experiment.attentionCheckParams
+                    ?.prolificAttentionFailRedirectCode
+                    ? html`, failed redirect code:
+                      ${experiment.attentionCheckParams
+                        ?.prolificAttentionFailRedirectCode}`
+                    : ''}
                   <br />
                 `
+              : ''}
+            ${experiment?.attentionCheckParams
+              ? html`${experiment.attentionCheckParams.waitSeconds
+                  ? html`
+                      Attention check parameters:
+                      ${experiment.attentionCheckParams.waitSeconds !==
+                      undefined
+                        ? html`${experiment.attentionCheckParams.waitSeconds}
+                          seconds wait, `
+                        : ''}
+                      ${experiment.attentionCheckParams.popupSeconds !==
+                      undefined
+                        ? html`${experiment.attentionCheckParams.popupSeconds}
+                            popup seconds<br />`
+                        : ''}
+                    `
+                  : ''}`
               : ''}
           </div>
           ${this.renderGroup()}

--- a/lit/src/experiment-components/experiment/experiment_preview.ts
+++ b/lit/src/experiment-components/experiment/experiment_preview.ts
@@ -4,22 +4,22 @@ import '../../pair-components/tooltip';
 
 import '../profile/profile_preview';
 
-import {MobxLitElement} from '@adobe/lit-mobx';
-import {ParticipantProfile} from '@llm-mediation-experiments/utils';
-import {CSSResultGroup, html, nothing} from 'lit';
-import {customElement} from 'lit/decorators.js';
-import {convertUnifiedTimestampToDate} from '../../shared/utils';
+import { MobxLitElement } from '@adobe/lit-mobx';
+import { ParticipantProfile } from '@llm-mediation-experiments/utils';
+import { CSSResultGroup, html, nothing } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { convertUnifiedTimestampToDate } from '../../shared/utils';
 
-import {core} from '../../core/core';
-import {AuthService} from '../../services/auth_service';
-import {ExperimentConfigService} from '../../services/config/experiment_config_service';
-import {ExperimentService} from '../../services/experiment_service';
-import {ExperimenterService} from '../../services/experimenter_service';
-import {ParticipantService} from '../../services/participant_service';
-import {Pages, RouterService} from '../../services/router_service';
+import { core } from '../../core/core';
+import { AuthService } from '../../services/auth_service';
+import { ExperimentConfigService } from '../../services/config/experiment_config_service';
+import { ExperimentService } from '../../services/experiment_service';
+import { ExperimenterService } from '../../services/experimenter_service';
+import { ParticipantService } from '../../services/participant_service';
+import { Pages, RouterService } from '../../services/router_service';
 
-import {PARTICIPANT_COMPLETION_TYPE} from '@llm-mediation-experiments/utils';
-import {styles} from './experiment_preview.scss';
+import { PARTICIPANT_COMPLETION_TYPE } from '@llm-mediation-experiments/utils';
+import { styles } from './experiment_preview.scss';
 
 /** Experiment preview */
 @customElement('experiment-preview')
@@ -107,12 +107,10 @@ export class ExperimentPreview extends MobxLitElement {
     const transferredParticipants = participants.filter(
       (participant) => participant.transferConfig
     );
-    const timedOutParticipants = participants.filter(
+    const failedParticipants = participants.filter(
       (participant) =>
-        participant.completionType ===
-          PARTICIPANT_COMPLETION_TYPE.ATTENTION_TIMEOUT ||
-        participant.completionType ===
-          PARTICIPANT_COMPLETION_TYPE.LOBBY_TIMEOUT ||
+        (participant.completionType &&
+          participant.completionType !== PARTICIPANT_COMPLETION_TYPE.SUCCESS) ||
         (!participant.completionType &&
           this.experimentService.experiment?.isLobby &&
           participant.completedExperiment &&
@@ -223,11 +221,11 @@ export class ExperimentPreview extends MobxLitElement {
             </div>
           `
         : ''}
-      ${timedOutParticipants.length > 0
+      ${failedParticipants.length > 0
         ? html`
-            <h2>${timedOutParticipants.length} timed out participants</h2>
+            <h2>${failedParticipants.length} failed participants</h2>
             <div class="profile-wrapper">
-              ${timedOutParticipants.map(
+              ${failedParticipants.map(
                 (participant) => html`
                   <profile-preview .profile=${participant}></profile-preview>
                 `

--- a/lit/src/experiment-components/experiment/experiment_preview.ts
+++ b/lit/src/experiment-components/experiment/experiment_preview.ts
@@ -115,10 +115,7 @@ export class ExperimentPreview extends MobxLitElement {
     const completedParticipants = participants.filter(
       (participant) =>
         participant.completedExperiment &&
-        !(
-          this.experimentService.experiment?.isLobby &&
-          !participant.transferConfig
-        )
+        !this.experimentService.experiment?.isLobby
     );
 
     const experiment = this.experimentService.experiment;

--- a/lit/src/experiment-components/footer/footer.ts
+++ b/lit/src/experiment-components/footer/footer.ts
@@ -10,6 +10,7 @@ import {ParticipantService} from '../../services/participant_service';
 import {Pages, RouterService} from '../../services/router_service';
 import {SurveyService} from '../../services/survey_service';
 
+import {PARTICIPANT_COMPLETION_TYPE} from '@llm-mediation-experiments/utils';
 import {PROLIFIC_COMPLETION_URL_PREFIX} from '../../shared/constants';
 import {styles} from './footer.scss';
 
@@ -60,7 +61,7 @@ export class Footer extends MobxLitElement {
   handleTimedOut() {
     this.clearCountdown();
     alert('Time is up, the experiment has ended!');
-    this.redirectEndExperiment();
+    this.redirectEndExperiment(PARTICIPANT_COMPLETION_TYPE.LOBBY_TIMEOUT);
   }
 
   startCountdown() {
@@ -90,8 +91,10 @@ export class Footer extends MobxLitElement {
     return `${minutes}:${secs.toString().padStart(2, '0')}`;
   }
 
-  redirectEndExperiment() {
-    this.participantService.markExperimentCompleted();
+  redirectEndExperiment(
+    completionType: PARTICIPANT_COMPLETION_TYPE = PARTICIPANT_COMPLETION_TYPE.SUCCESS
+  ) {
+    this.participantService.markExperimentCompleted(completionType);
 
     if (this.experimentService.experiment?.prolificRedirectCode) {
       // Navigate to Prolific with completion code.

--- a/lit/src/experiment-components/footer/footer.ts
+++ b/lit/src/experiment-components/footer/footer.ts
@@ -175,7 +175,8 @@ export class Footer extends MobxLitElement {
     };
 
     const preventNextClick =
-      this.disabled || !this.participantService.isCurrentStage();
+      this.disabled || !this.participantService.isCurrentStage() ||
+      this.participantService.profile?.completedExperiment;
 
     // If completed lobby experiment, render link to transfer experiment
     if (isLastStage && this.experimentService.experiment?.isLobby) {

--- a/lit/src/experiment-components/footer/footer.ts
+++ b/lit/src/experiment-components/footer/footer.ts
@@ -129,6 +129,8 @@ export class Footer extends MobxLitElement {
         </div>
         <div class="right">${this.renderNextStageButton()}</div>
       </div>
+
+      <!-- Popup listener -->
       <transfer-popup
         .open=${this.showTransferPopup}
         @confirm-transfer=${this.handleTransfer}
@@ -138,6 +140,13 @@ export class Footer extends MobxLitElement {
 
   private renderNextStageButton() {
     const isLastStage = this.isOnLastStage();
+    if (
+      this.participantService.profile?.completionType ===
+      PARTICIPANT_COMPLETION_TYPE.BOOTED_OUT
+    ) {
+      alert('You have been removed from this experiment.');
+      this.routerService.navigate(Pages.HOME);
+    }
 
     const handleNext = async () => {
       // If survey stage, save relevant text answers

--- a/lit/src/experiment-components/games/lost_at_sea/las_survey_preview.ts
+++ b/lit/src/experiment-components/games/lost_at_sea/las_survey_preview.ts
@@ -1,14 +1,14 @@
-import "../../../pair-components/textarea";
+import '../../../pair-components/textarea';
 
-import "../../footer/footer";
-import "../../progress/progress_stage_completed";
+import '../../footer/footer';
+import '../../progress/progress_stage_completed';
 
 import '@material/web/radio/radio.js';
 
-import { MobxLitElement } from "@adobe/lit-mobx";
-import { CSSResultGroup, html, nothing } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { classMap } from "lit/directives/class-map.js";
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import {classMap} from 'lit/directives/class-map.js';
 
 import {
   ITEMS,
@@ -17,22 +17,23 @@ import {
   LostAtSeaQuestionAnswer,
   LostAtSeaSurveyStageAnswer,
   LostAtSeaSurveyStageConfig,
-} from "@llm-mediation-experiments/utils";
+} from '@llm-mediation-experiments/utils';
 
-import { core } from "../../../core/core";
-import { ParticipantService } from "../../../services/participant_service";
-
-import { styles } from "./las_survey_preview.scss";
+import {unsafeHTML} from 'lit/directives/unsafe-html.js';
+import {core} from '../../../core/core';
+import {ParticipantService} from '../../../services/participant_service';
+import {convertMarkdownToHTML} from '../../../shared/utils';
+import {styles} from './las_survey_preview.scss';
 
 /** Lost at Sea survey preview */
-@customElement("las-survey-preview")
+@customElement('las-survey-preview')
 export class SurveyPreview extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
   private readonly participantService = core.getService(ParticipantService);
 
-  @property() stage: LostAtSeaSurveyStageConfig|null = null;
-  @property() answer: LostAtSeaSurveyStageAnswer|null = null;
+  @property() stage: LostAtSeaSurveyStageConfig | null = null;
+  @property() answer: LostAtSeaSurveyStageAnswer | null = null;
 
   override render() {
     if (!this.stage) {
@@ -45,7 +46,7 @@ export class SurveyPreview extends MobxLitElement {
 
       if (answerList.length != this.stage?.questions.length) {
         return false;
-      };
+      }
 
       // Confirm that user has selected confidence for each question
       for (const answer of answerList) {
@@ -56,13 +57,17 @@ export class SurveyPreview extends MobxLitElement {
       return true;
     };
 
-    const descriptionContent = this.stage.description ? html`<div class="description">${this.stage.description}</div>` : nothing;
+    const descriptionContent = this.stage.description
+      ? html`<div class="description">
+          ${unsafeHTML(convertMarkdownToHTML(this.stage.description))}
+        </div>`
+      : nothing;
 
     return html`
       ${descriptionContent}
-      
+
       <div class="questions-wrapper">
-        ${this.stage.questions.map(question => this.renderQuestion(question))}
+        ${this.stage.questions.map((question) => this.renderQuestion(question))}
       </div>
       <stage-footer .disabled=${!ratingsComplete()}>
         <progress-stage-completed></progress-stage-completed>
@@ -78,14 +83,16 @@ export class SurveyPreview extends MobxLitElement {
       }
 
       const confidence = this.getQuestionConfidence(question);
-      const answer: LostAtSeaQuestionAnswer = confidence ? {
-        id: question.id,
-        choice,
-        confidence: this.getQuestionConfidence(question),
-      } : {
-        id: question.id,
-        choice
-      };
+      const answer: LostAtSeaQuestionAnswer = confidence
+        ? {
+            id: question.id,
+            choice,
+            confidence: this.getQuestionConfidence(question),
+          }
+        : {
+            id: question.id,
+            choice,
+          };
 
       this.participantService.updateLostAtSeaSurveyStage(
         this.participantService.profile!.currentStageId,
@@ -101,22 +108,25 @@ export class SurveyPreview extends MobxLitElement {
       }
 
       return false;
-    }
+    };
 
     const getClassMap = (item: string) => {
       return classMap({
-        "question": true,
-        "selected": isMatch(item),
-        "disabled": !this.participantService.isCurrentStage()
+        question: true,
+        selected: isMatch(item),
+        disabled: !this.participantService.isCurrentStage(),
       });
-    }
+    };
 
     return html`
       <div class="survey-question">
         <div class="question-title">${question.questionText}</div>
         <div class="question-wrapper">
-          <div class=${getClassMap(question.item1)}
-            @click=${() => { onSelect(question.item1); }}
+          <div
+            class=${getClassMap(question.item1)}
+            @click=${() => {
+              onSelect(question.item1);
+            }}
           >
             <div class="img-wrapper">
               <img src=${ITEMS[question.item1].imageUrl} />
@@ -128,14 +138,18 @@ export class SurveyPreview extends MobxLitElement {
                 value="1"
                 aria-label=${ITEMS[question.item1].name}
                 ?checked=${isMatch(question.item1)}
-                ?disabled=${!this.participantService.isCurrentStage()}>
+                ?disabled=${!this.participantService.isCurrentStage()}
+              >
               </md-radio>
               <label for="1">${ITEMS[question.item1].name}</label>
             </div>
           </div>
-          <div class=${getClassMap(question.item2)}
-              @click=${() => { onSelect(question.item2); }}
-            >
+          <div
+            class=${getClassMap(question.item2)}
+            @click=${() => {
+              onSelect(question.item2);
+            }}
+          >
             <div class="img-wrapper">
               <img src=${ITEMS[question.item2].imageUrl} />
             </div>
@@ -146,7 +160,8 @@ export class SurveyPreview extends MobxLitElement {
                 value="2"
                 aria-label=${ITEMS[question.item2].name}
                 ?checked=${isMatch(question.item2)}
-                ?disabled=${!this.participantService.isCurrentStage()}>
+                ?disabled=${!this.participantService.isCurrentStage()}
+              >
               </md-radio>
               <label for="2">${ITEMS[question.item2].name}</label>
             </div>
@@ -182,19 +197,24 @@ export class SurveyPreview extends MobxLitElement {
 
     return html`
       <div class="confidence-question">
-        <div class="title">How confident are you that your answer is correct?</div>
+        <div class="title">
+          How confident are you that your answer is correct?
+        </div>
         <div class="confidence-scale labels">
           <div>Not confident</div>
           <div>Very confident</div>
         </div>
         <div class="confidence-scale values">
-          ${scale.map(num => this.renderConfidenceRadioButton(question, num))}
+          ${scale.map((num) => this.renderConfidenceRadioButton(question, num))}
         </div>
       </div>
     `;
   }
 
-  private renderConfidenceRadioButton(question: LostAtSeaQuestion, value: number) {
+  private renderConfidenceRadioButton(
+    question: LostAtSeaQuestion,
+    value: number
+  ) {
     const name = `${question.id}-confidence`;
     const id = `${question.id}-confidence-${value}`;
 
@@ -236,7 +256,8 @@ export class SurveyPreview extends MobxLitElement {
           value=${value}
           aria-label=${value}
           ?checked=${isConfidenceChoiceMatch(value)}
-          ?disabled=${!this.participantService.isCurrentStage() || !this.answer?.answers[question.id]}
+          ?disabled=${!this.participantService.isCurrentStage() ||
+          !this.answer?.answers[question.id]}
           @change=${handleConfidenceClick}
         >
         </md-radio>
@@ -248,6 +269,6 @@ export class SurveyPreview extends MobxLitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "las-survey-preview": SurveyPreview;
+    'las-survey-preview': SurveyPreview;
   }
 }

--- a/lit/src/experiment-components/info/info_preview.ts
+++ b/lit/src/experiment-components/info/info_preview.ts
@@ -1,37 +1,40 @@
-import "../../pair-components/textarea";
+import '../../pair-components/textarea';
 
-import "../footer/footer";
-import "../progress/progress_stage_completed";
+import '../footer/footer';
+import '../progress/progress_stage_completed';
 
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
 
-import { MobxLitElement } from "@adobe/lit-mobx";
-import { CSSResultGroup, html, nothing } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import {InfoStageConfig} from '@llm-mediation-experiments/utils';
 
-import { InfoStageConfig } from "@llm-mediation-experiments/utils";
-
-import { styles } from "./info_preview.scss";
-import { convertMarkdownToHTML } from "../../shared/utils";
-import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import {unsafeHTML} from 'lit/directives/unsafe-html.js';
+import {convertMarkdownToHTML} from '../../shared/utils';
+import {styles} from './info_preview.scss';
 
 /** Info preview */
-@customElement("info-preview")
+@customElement('info-preview')
 export class InfoPreview extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
-  @property() stage: InfoStageConfig|null = null;
+  @property() stage: InfoStageConfig | null = null;
 
   override render() {
     if (!this.stage) {
       return nothing;
     }
-    const descriptionContent = this.stage.description ? html`<div class="description">${this.stage.description}</div>` : nothing;
+    const descriptionContent = this.stage.description
+      ? html`<div class="description">
+          ${unsafeHTML(convertMarkdownToHTML(this.stage.description))}
+        </div>`
+      : nothing;
 
     return html`
       ${descriptionContent}
-      
+
       <div class="html-wrapper">
-        ${this.stage?.infoLines.map(line => this.renderInfoLine(line))}
+        ${this.stage?.infoLines.map((line) => this.renderInfoLine(line))}
       </div>
       <stage-footer>
         <progress-stage-completed></progress-stage-completed>
@@ -41,16 +44,13 @@ export class InfoPreview extends MobxLitElement {
 
   private renderInfoLine(line: string) {
     return html`
-      <div class="info-block">
-        ${unsafeHTML(convertMarkdownToHTML(line))}
-      </div>
+      <div class="info-block">${unsafeHTML(convertMarkdownToHTML(line))}</div>
     `;
-    }
-
+  }
 }
 
 declare global {
   interface HTMLElementTagNameMap {
-    "info-preview": InfoPreview;
+    'info-preview': InfoPreview;
   }
 }

--- a/lit/src/experiment-components/payout/payout_config.ts
+++ b/lit/src/experiment-components/payout/payout_config.ts
@@ -1,11 +1,11 @@
-import "../../pair-components/button"
-import "../../pair-components/icon_button";
-import "../../pair-components/menu";
-import "../../pair-components/textarea"
+import '../../pair-components/button';
+import '../../pair-components/icon_button';
+import '../../pair-components/menu';
+import '../../pair-components/textarea';
 
-import { MobxLitElement } from "@adobe/lit-mobx";
-import { CSSResultGroup, html, nothing } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html} from 'lit';
+import {customElement} from 'lit/decorators.js';
 
 import {
   PayoutBundle,
@@ -13,20 +13,19 @@ import {
   PayoutCurrency,
   PayoutItem,
   PayoutItemStrategy,
-  StageConfig
-} from "@llm-mediation-experiments/utils";
+} from '@llm-mediation-experiments/utils';
 
-import { core } from "../../core/core";
-import { ExperimentConfigService } from "../../services/config/experiment_config_service";
-import { PayoutConfigService } from "../../services/config/payout_config_service";
+import {core} from '../../core/core';
+import {ExperimentConfigService} from '../../services/config/experiment_config_service';
+import {PayoutConfigService} from '../../services/config/payout_config_service';
 
-import { getElectionStages } from "../../shared/utils";
-  import { getLostAtSeaSurveyStages } from "../../shared/lost_at_sea/utils";
+import {getLostAtSeaSurveyStages} from '../../shared/lost_at_sea/utils';
+import {getElectionStages} from '../../shared/utils';
 
-import { styles } from "./payout_config.scss";
+import {styles} from './payout_config.scss';
 
 /** Payout config */
-@customElement("payout-config")
+@customElement('payout-config')
 export class PayoutConfig extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
@@ -36,11 +35,11 @@ export class PayoutConfig extends MobxLitElement {
   override render() {
     const addPayoutBundle = () => {
       this.payoutConfig.addPayoutBundle();
-    }
+    };
 
     const handleCurrency = (currency: PayoutCurrency) => {
       this.payoutConfig.updatePayoutCurrency(currency);
-    }
+    };
 
     return html`
       <div class="title-wrapper">
@@ -48,31 +47,40 @@ export class PayoutConfig extends MobxLitElement {
         <pr-button @click=${addPayoutBundle}>Add new payout group</pr-button>
       </div>
       <div class="description">
-        All payout groups will be added together to calculate the total
-        payout
+        All payout groups will be added together to calculate the total payout
       </div>
       <div class="options-wrapper">
         <div class="options-title">Currency</div>
         <div class="options col">
           <div
             role="button"
-            class="option ${this.payoutConfig.stage?.currency === PayoutCurrency.USD ? 'selected': ''}"
-            @click=${() => { handleCurrency(PayoutCurrency.USD)}}
+            class="option ${this.payoutConfig.stage?.currency ===
+            PayoutCurrency.USD
+              ? 'selected'
+              : ''}"
+            @click=${() => {
+              handleCurrency(PayoutCurrency.USD);
+            }}
           >
             US Dollar (USD)
           </div>
           <div
             role="button"
-            class="option ${this.payoutConfig.stage?.currency === PayoutCurrency.EUR ? 'selected': ''}"
-            @click=${() => { handleCurrency(PayoutCurrency.EUR)}}
+            class="option ${this.payoutConfig.stage?.currency ===
+            PayoutCurrency.EUR
+              ? 'selected'
+              : ''}"
+            @click=${() => {
+              handleCurrency(PayoutCurrency.EUR);
+            }}
           >
             Euro (EUR)
           </div>
         </div>
       </div>
       <div class="payouts-wrapper">
-        ${this.payoutConfig.payouts.map(
-          (bundle, index) => this.renderPayoutBundle(bundle, index)
+        ${this.payoutConfig.payouts.map((bundle, index) =>
+          this.renderPayoutBundle(bundle, index)
         )}
       </div>
     `;
@@ -95,20 +103,18 @@ export class PayoutConfig extends MobxLitElement {
 
     const updatePayoutBundleName = (e: Event) => {
       const value = (e.target as HTMLTextAreaElement).value;
-      this.payoutConfig.updatePayoutBundle(index, { name: value });
+      this.payoutConfig.updatePayoutBundle(index, {name: value});
     };
 
     const handleStrategy = (strategy: PayoutBundleStrategy) => {
-      this.payoutConfig.updatePayoutBundle(index, { strategy });
+      this.payoutConfig.updatePayoutBundle(index, {strategy});
     };
 
     const addRatingSurveyPayoutItem = () => {
       const surveys = getLostAtSeaSurveyStages(this.experimentConfig.stages);
       if (surveys.length === 0) return;
 
-      this.payoutConfig.addRatingSurveyPayoutItemToBundle(
-        index, surveys[0].id,
-      );
+      this.payoutConfig.addRatingSurveyPayoutItemToBundle(index, surveys[0].id);
     };
 
     return html`
@@ -117,7 +123,7 @@ export class PayoutConfig extends MobxLitElement {
           <pr-textarea
             placeholder="Untitled payout group"
             size="medium"
-            .value=${payoutBundle.name ?? ""}
+            .value=${payoutBundle.name ?? ''}
             @input=${updatePayoutBundleName}
           >
           </pr-textarea>
@@ -158,15 +164,25 @@ export class PayoutConfig extends MobxLitElement {
           <div class="options col">
             <div
               role="button"
-              class="option ${payoutBundle.strategy === PayoutBundleStrategy.AddPayoutItems ? 'selected': ''}"
-              @click=${() => { handleStrategy(PayoutBundleStrategy.AddPayoutItems)}}
+              class="option ${payoutBundle.strategy ===
+              PayoutBundleStrategy.AddPayoutItems
+                ? 'selected'
+                : ''}"
+              @click=${() => {
+                handleStrategy(PayoutBundleStrategy.AddPayoutItems);
+              }}
             >
               Add all payout items together
             </div>
             <div
               role="button"
-              class="option ${payoutBundle.strategy === PayoutBundleStrategy.ChoosePayoutItem ? 'selected': ''}"
-              @click=${() => { handleStrategy(PayoutBundleStrategy.ChoosePayoutItem)}}
+              class="option ${payoutBundle.strategy ===
+              PayoutBundleStrategy.ChoosePayoutItem
+                ? 'selected'
+                : ''}"
+              @click=${() => {
+                handleStrategy(PayoutBundleStrategy.ChoosePayoutItem);
+              }}
             >
               Choose one of the following payout items
             </div>
@@ -176,21 +192,24 @@ export class PayoutConfig extends MobxLitElement {
           <pr-button
             color="secondary"
             variant="default"
-            ?disabled=${getLostAtSeaSurveyStages(this.experimentConfig.stages).length === 0}
+            ?disabled=${getLostAtSeaSurveyStages(this.experimentConfig.stages)
+              .length === 0}
             @click=${addRatingSurveyPayoutItem}
           >
             Add payout item
           </pr-button>
         </div>
-        ${payoutBundle.payoutItems.map(
-          (item, itemIndex) => this.renderPayoutItem(item, itemIndex, index)
+        ${payoutBundle.payoutItems.map((item, itemIndex) =>
+          this.renderPayoutItem(item, itemIndex, index)
         )}
       </div>
     `;
   }
 
   private renderPayoutItem(
-    payoutItem: PayoutItem, itemIndex: number, bundleIndex: number
+    payoutItem: PayoutItem,
+    itemIndex: number,
+    bundleIndex: number
   ) {
     const handleDelete = () => {
       this.payoutConfig.removePayoutItem(bundleIndex, itemIndex);
@@ -221,41 +240,54 @@ export class PayoutConfig extends MobxLitElement {
     `;
   }
 
-  private renderSurveyStageOptions(payoutItem: PayoutItem, itemIndex: number, bundleIndex: number) {
+  private renderSurveyStageOptions(
+    payoutItem: PayoutItem,
+    itemIndex: number,
+    bundleIndex: number
+  ) {
     const updateSurveyStageId = (surveyStageId: string) => {
-      this.payoutConfig.updatePayoutItem(
-        bundleIndex, itemIndex, { surveyStageId }
-      );
+      this.payoutConfig.updatePayoutItem(bundleIndex, itemIndex, {
+        surveyStageId,
+      });
     };
 
     return html`
       <div class="options-wrapper">
         <div class="options-title">Survey used for answers</div>
         <div class="options">
-          ${getLostAtSeaSurveyStages(this.experimentConfig.stages).map(stage =>
-          html`
-            <div
-              role="button"
-              class="option ${payoutItem.surveyStageId === stage.id ? 'selected' : ''}"
-              @click=${() => {updateSurveyStageId(stage.id)}}
-            >
-              ${stage.name}
-            </div>
-          `
+          ${getLostAtSeaSurveyStages(this.experimentConfig.stages).map(
+            (stage) =>
+              html`
+                <div
+                  role="button"
+                  class="option ${payoutItem.surveyStageId === stage.id
+                    ? 'selected'
+                    : ''}"
+                  @click=${() => {
+                    updateSurveyStageId(stage.id);
+                  }}
+                >
+                  ${stage.name}
+                </div>
+              `
           )}
         </div>
       </div>
     `;
   }
 
-  private renderSurveyQuestionOptions(payoutItem: PayoutItem, itemIndex: number, bundleIndex: number) {
-    const surveyStage = this.experimentConfig.getStage(payoutItem.surveyStageId);
+  private renderSurveyQuestionOptions(
+    payoutItem: PayoutItem,
+    itemIndex: number,
+    bundleIndex: number
+  ) {
+    const surveyStage = this.experimentConfig.getStage(
+      payoutItem.surveyStageId
+    );
     if (!surveyStage) return;
 
     const updateStrategy = (strategy: PayoutItemStrategy) => {
-      this.payoutConfig.updatePayoutItem(
-        bundleIndex, itemIndex, { strategy }
-      );
+      this.payoutConfig.updatePayoutItem(bundleIndex, itemIndex, {strategy});
     };
 
     return html`
@@ -264,15 +296,23 @@ export class PayoutConfig extends MobxLitElement {
         <div class="options">
           <div
             role="button"
-            class="option ${payoutItem.strategy === PayoutItemStrategy.AddAll ? 'selected': ''}"
-            @click=${() => {updateStrategy(PayoutItemStrategy.AddAll)}}
+            class="option ${payoutItem.strategy === PayoutItemStrategy.AddAll
+              ? 'selected'
+              : ''}"
+            @click=${() => {
+              updateStrategy(PayoutItemStrategy.AddAll);
+            }}
           >
             Use all questions
           </div>
           <div
             role="button"
-            class="option ${payoutItem.strategy === PayoutItemStrategy.ChooseOne ? 'selected' : ''}"
-            @click=${() => {updateStrategy(PayoutItemStrategy.ChooseOne)}}
+            class="option ${payoutItem.strategy === PayoutItemStrategy.ChooseOne
+              ? 'selected'
+              : ''}"
+            @click=${() => {
+              updateStrategy(PayoutItemStrategy.ChooseOne);
+            }}
           >
             Randomly select one question
           </div>
@@ -281,22 +321,38 @@ export class PayoutConfig extends MobxLitElement {
     `;
   }
 
-  private renderSurveyAmountOptions(payoutItem: PayoutItem, itemIndex: number, bundleIndex: number) {
+  private renderSurveyAmountOptions(
+    payoutItem: PayoutItem,
+    itemIndex: number,
+    bundleIndex: number
+  ) {
     const updateQuestionAmount = (e: Event) => {
-      const currencyAmountPerQuestion = Number((e.target as HTMLTextAreaElement).value);
-      this.payoutConfig.updatePayoutItem(bundleIndex, itemIndex, { currencyAmountPerQuestion })
+      const currencyAmountPerQuestion = Number(
+        (e.target as HTMLTextAreaElement).value
+      );
+      this.payoutConfig.updatePayoutItem(bundleIndex, itemIndex, {
+        currencyAmountPerQuestion,
+      });
     };
 
     const updateFixedAmount = (e: Event) => {
-      const fixedCurrencyAmount = Number((e.target as HTMLTextAreaElement).value);
-      this.payoutConfig.updatePayoutItem(bundleIndex, itemIndex, { fixedCurrencyAmount })
+      const fixedCurrencyAmount = Number(
+        (e.target as HTMLTextAreaElement).value
+      );
+      this.payoutConfig.updatePayoutItem(bundleIndex, itemIndex, {
+        fixedCurrencyAmount,
+      });
     };
 
     return html`
       <div class="number-input">
         <label>Amount per question</label>
         <div class="input-wrapper">
-          <div>${this.payoutConfig.stage?.currency === PayoutCurrency.USD ? '$' : '€'}</div>
+          <div>
+            ${this.payoutConfig.stage?.currency === PayoutCurrency.USD
+              ? '$'
+              : '€'}
+          </div>
           <input
             type="number"
             .value=${payoutItem.currencyAmountPerQuestion}
@@ -307,7 +363,11 @@ export class PayoutConfig extends MobxLitElement {
       <div class="number-input">
         <label>Fixed amount (to add at the end)</label>
         <div class="input-wrapper">
-          <div>${this.payoutConfig.stage?.currency === PayoutCurrency.USD ? '$' : '€'}</div>
+          <div>
+            ${this.payoutConfig.stage?.currency === PayoutCurrency.USD
+              ? '$'
+              : '€'}
+          </div>
           <input
             .value=${payoutItem.fixedCurrencyAmount}
             @input=${updateFixedAmount}
@@ -318,11 +378,15 @@ export class PayoutConfig extends MobxLitElement {
     `;
   }
 
-  private renderElectionStageOptions(payoutItem: PayoutItem, itemIndex: number, bundleIndex: number) {
+  private renderElectionStageOptions(
+    payoutItem: PayoutItem,
+    itemIndex: number,
+    bundleIndex: number
+  ) {
     const updateLeaderStageId = (leaderStageId: string) => {
-      this.payoutConfig.updatePayoutItem(
-        bundleIndex, itemIndex, { leaderStageId }
-      );
+      this.payoutConfig.updatePayoutItem(bundleIndex, itemIndex, {
+        leaderStageId,
+      });
     };
 
     return html`
@@ -331,17 +395,26 @@ export class PayoutConfig extends MobxLitElement {
         <div class="options">
           <div
             role="button"
-            class="option ${!payoutItem.leaderStageId || payoutItem.leaderStageId === '' ? 'selected' : ''}"
-            @click=${() => {updateLeaderStageId('')}}
+            class="option ${!payoutItem.leaderStageId ||
+            payoutItem.leaderStageId === ''
+              ? 'selected'
+              : ''}"
+            @click=${() => {
+              updateLeaderStageId('');
+            }}
           >
             Current participant
           </div>
           ${getElectionStages(this.experimentConfig.stages).map(
-            stage => html`
+            (stage) => html`
               <div
                 role="button"
-                class="option ${payoutItem.leaderStageId === stage.id ? 'selected' : ''}"
-                @click=${() => {updateLeaderStageId(stage.id)}}
+                class="option ${payoutItem.leaderStageId === stage.id
+                  ? 'selected'
+                  : ''}"
+                @click=${() => {
+                  updateLeaderStageId(stage.id);
+                }}
               >
                 Leader from: ${stage.name}
               </div>
@@ -355,6 +428,6 @@ export class PayoutConfig extends MobxLitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "payout-config": PayoutConfig;
+    'payout-config': PayoutConfig;
   }
 }

--- a/lit/src/experiment-components/payout/payout_preview.ts
+++ b/lit/src/experiment-components/payout/payout_preview.ts
@@ -1,32 +1,33 @@
-import "../footer/footer";
-import "../progress/progress_stage_completed";
-import "../election/election_reveal";
-import "../games/lost_at_sea/las_result";
+import '../election/election_reveal';
+import '../footer/footer';
+import '../games/lost_at_sea/las_result';
+import '../progress/progress_stage_completed';
 
-import { MobxLitElement } from "@adobe/lit-mobx";
-import { CSSResultGroup, html, nothing } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
 
 import {
-  ItemName,
   ITEMS,
-  LostAtSeaSurveyStageAnswer,
+  ItemName,
   LostAtSeaQuestionAnswer,
+  LostAtSeaSurveyStageAnswer,
+  LostAtSeaSurveyStagePublicData,
   PayoutCurrency,
   PayoutStageConfig,
   ScoringBundle,
   ScoringItem,
   ScoringQuestion,
-  StageKind,
-  LostAtSeaSurveyStagePublicData,
   VoteForLeaderStagePublicData,
-} from "@llm-mediation-experiments/utils";
+} from '@llm-mediation-experiments/utils';
 
-import { core } from "../../core/core";
-import { ExperimentService } from "../../services/experiment_service";
-import { ParticipantService } from "../../services/participant_service";
+import {core} from '../../core/core';
+import {ExperimentService} from '../../services/experiment_service';
+import {ParticipantService} from '../../services/participant_service';
 
-import { styles } from "./payout_preview.scss";
+import {unsafeHTML} from 'lit/directives/unsafe-html.js';
+import {convertMarkdownToHTML} from '../../shared/utils';
+import {styles} from './payout_preview.scss';
 
 interface AnswerItem extends ScoringQuestion {
   leaderPublicId?: string; // leader public ID if used
@@ -34,14 +35,14 @@ interface AnswerItem extends ScoringQuestion {
 }
 
 /** Payout preview */
-@customElement("payout-preview")
+@customElement('payout-preview')
 export class PayoutPreview extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
   private readonly experimentService = core.getService(ExperimentService);
   private readonly participantService = core.getService(ParticipantService);
 
-  @property() stage: PayoutStageConfig|null = null;
+  @property() stage: PayoutStageConfig | null = null;
 
   override render() {
     if (this.stage === null) {
@@ -51,10 +52,12 @@ export class PayoutPreview extends MobxLitElement {
     const scoring = this.stage.scoring ?? [];
 
     return html`
-      <div class="description">${this.stage?.description}</div>
+      <div class="description">
+        ${unsafeHTML(convertMarkdownToHTML(this.stage?.description!))}
+      </div>
 
       <div class="stages-wrapper">
-        ${scoring.map(bundle => this.renderScoringBundle(bundle))}
+        ${scoring.map((bundle) => this.renderScoringBundle(bundle))}
       </div>
       <stage-footer .disabled=${!this.participantService.isCurrentStage()}>
         <progress-stage-completed></progress-stage-completed>
@@ -66,36 +69,53 @@ export class PayoutPreview extends MobxLitElement {
     return html`
       <div class="scoring-bundle">
         <h2>${bundle.name}</h2>
-        ${bundle.scoringItems.map(item => this.renderScoringItem(item))}
+        ${bundle.scoringItems.map((item) => this.renderScoringItem(item))}
       </div>
     `;
   }
 
   private renderAmount(amount: number) {
-    return this.stage?.currency === PayoutCurrency.USD ? `$${amount}` : `€${amount}`;
+    return this.stage?.currency === PayoutCurrency.USD
+      ? `$${amount}`
+      : `€${amount}`;
   }
 
   private getAnswerItems(item: ScoringItem): AnswerItem[] {
     // Use leader's answers if indicated, else current participant's answers
 
     if (item.leaderStageId && item.leaderStageId.length > 0) {
-      const leaderPublicId = (this.experimentService.publicStageDataMap[item.leaderStageId] as VoteForLeaderStagePublicData).currentLeader ?? '';
-      const leaderAnswers = (this.experimentService.publicStageDataMap[item.surveyStageId] as LostAtSeaSurveyStagePublicData).participantAnswers[leaderPublicId];
+      const leaderPublicId =
+        (
+          this.experimentService.publicStageDataMap[
+            item.leaderStageId
+          ] as VoteForLeaderStagePublicData
+        ).currentLeader ?? '';
+      const leaderAnswers = (
+        this.experimentService.publicStageDataMap[
+          item.surveyStageId
+        ] as LostAtSeaSurveyStagePublicData
+      ).participantAnswers[leaderPublicId];
 
       return item.questions.map((question) => {
         return {
           ...question,
           leaderPublicId,
-          userAnswer: (leaderAnswers[question.id] as LostAtSeaQuestionAnswer).choice,
+          userAnswer: (leaderAnswers[question.id] as LostAtSeaQuestionAnswer)
+            .choice,
         };
       });
     }
 
-    const userAnswers = (this.participantService.stageAnswers[item.surveyStageId] as LostAtSeaSurveyStageAnswer).answers;
+    const userAnswers = (
+      this.participantService.stageAnswers[
+        item.surveyStageId
+      ] as LostAtSeaSurveyStageAnswer
+    ).answers;
     return item.questions.map((question) => {
       return {
         ...question,
-        userAnswer: (userAnswers[question.id] as LostAtSeaQuestionAnswer).choice,
+        userAnswer: (userAnswers[question.id] as LostAtSeaQuestionAnswer)
+          .choice,
       };
     });
   }
@@ -104,7 +124,7 @@ export class PayoutPreview extends MobxLitElement {
     const answerItems: AnswerItem[] = this.getAnswerItems(item);
     const numCorrect = () => {
       let count = 0;
-      answerItems.forEach(answer => {
+      answerItems.forEach((answer) => {
         if (answer.userAnswer === answer.answer) {
           count += 1;
         }
@@ -115,7 +135,7 @@ export class PayoutPreview extends MobxLitElement {
     return html`
       <div class="scoring-item">
         <h3>${this.experimentService.getStageName(item.surveyStageId)}</h3>
-        ${answerItems.map(answerItem => this.renderAnswerItem(answerItem))}
+        ${answerItems.map((answerItem) => this.renderAnswerItem(answerItem))}
         <div class="amount-wrapper">
           <div class="chip secondary">
             ${this.renderAmount(item.fixedCurrencyAmount)}
@@ -124,9 +144,12 @@ export class PayoutPreview extends MobxLitElement {
           <div class="chip secondary">
             ${this.renderAmount(item.currencyAmountPerQuestion)}
           </div>
-            x ${numCorrect()} correct questions =
+          x ${numCorrect()} correct questions =
           <div class="chip">
-            ${this.renderAmount(item.fixedCurrencyAmount + item.currencyAmountPerQuestion * numCorrect())}
+            ${this.renderAmount(
+              item.fixedCurrencyAmount +
+                item.currencyAmountPerQuestion * numCorrect()
+            )}
             total
           </div>
         </div>
@@ -142,12 +165,12 @@ export class PayoutPreview extends MobxLitElement {
     return html`
       <div class="answer-item">
         <div class="primary">
-          ${getName(item.questionOptions[0])}
-          vs.
+          ${getName(item.questionOptions[0])} vs.
           ${getName(item.questionOptions[1])}
         </div>
         <div class="result">Correct answer: ${getName(item.answer)}</div>
-        <div class="result">Your ${item.leaderPublicId ? "leader\'s " : ""}answer:
+        <div class="result">
+          Your ${item.leaderPublicId ? "leader's " : ''}answer:
           <span class="chip secondary">${getName(item.userAnswer)}</span>
         </div>
       </div>
@@ -157,6 +180,6 @@ export class PayoutPreview extends MobxLitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "payout-preview": PayoutPreview;
+    'payout-preview': PayoutPreview;
   }
 }

--- a/lit/src/experiment-components/popup/popup.scss
+++ b/lit/src/experiment-components/popup/popup.scss
@@ -1,0 +1,25 @@
+@use "../../sass/common";
+@use "../../sass/colors";
+@use "../../sass/typescale";
+
+.overlay {
+  @include common.flex-row-align-center;
+  background-color: rgba(0, 0, 0, .8);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  position: fixed;
+  z-index: 1;
+}
+.popup {
+  @include common.flex-column;
+  @include typescale.body-small;
+  background: var(--md-sys-color-surface-variant);
+  border-radius: common.$spacing-medium;
+  box-shadow: var(--md-sys-color-box-shadow-3);
+  color: var(--md-sys-color-on-surface);
+  gap: common.$spacing-xxl;
+  max-width: 80vw;
+  padding: common.$spacing-xxl;
+  width: max-content;
+}

--- a/lit/src/experiment-components/popup/transfer_popup.ts
+++ b/lit/src/experiment-components/popup/transfer_popup.ts
@@ -1,0 +1,33 @@
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import {styles} from './popup.scss';
+
+@customElement('transfer-popup')
+class TransferPopup extends MobxLitElement {
+  static override styles: CSSResultGroup = [styles];
+
+  @property({type: Boolean}) open = false;
+
+  render() {
+    if (!this.open) return null;
+    return html`
+      <div class="overlay">
+        <div class="popup">
+          <p>You have been transferred to a new experiment!</p>
+          <pr-button color="secondary" variant="tonal" @click=${this.handleYes}>Join the experiment</button>
+        </div>
+      </div>
+    `;
+  }
+
+  private handleYes() {
+    this.dispatchEvent(new CustomEvent('confirm-transfer'));
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'transfer-popup': TransferPopup;
+  }
+}

--- a/lit/src/experiment-components/profile/profile_config.ts
+++ b/lit/src/experiment-components/profile/profile_config.ts
@@ -1,43 +1,40 @@
-import "../../pair-components/textarea";
+import '../../pair-components/textarea';
 
-import "../footer/footer";
-import "../progress/progress_stage_completed";
-import "./profile_avatar";
+import '../footer/footer';
+import '../progress/progress_stage_completed';
+import './profile_avatar';
 
-import "@material/web/radio/radio.js";
+import '@material/web/radio/radio.js';
 
-import { observable } from "mobx";
-import { MobxLitElement } from "@adobe/lit-mobx";
-import { CSSResultGroup, html } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { classMap } from "lit/directives/class-map.js";
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
 
-import { core } from "../../core/core";
-import { ParticipantService } from "../../services/participant_service";
+import {core} from '../../core/core';
+import {ParticipantService} from '../../services/participant_service';
 
-import { PROFILE_AVATARS } from "../../shared/constants";
+import {PROFILE_AVATARS} from '../../shared/constants';
 
-import { styles } from "./profile_config.scss";
+import {styles} from './profile_config.scss';
 
 /** Participant profile config */
-@customElement("profile-config")
+@customElement('profile-config')
 export class ProfileConfig extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
   private readonly participantService = core.getService(ParticipantService);
 
-  @property() customPronouns = "";
+  @property() customPronouns = '';
 
   override render() {
-    const filled = this.participantService.profile?.name &&
-        this.participantService.profile?.pronouns &&
-        this.participantService.profile?.avatarUrl;
+    const filled =
+      this.participantService.profile?.name &&
+      this.participantService.profile?.pronouns &&
+      this.participantService.profile?.avatarUrl;
 
     return html`
       <div class="profile-wrapper">
-        ${this.renderName()}
-        ${this.renderPronouns()}
-        ${this.renderAvatars()}
+        ${this.renderName()} ${this.renderPronouns()} ${this.renderAvatars()}
       </div>
       <stage-footer .disabled=${!filled}>
         <progress-stage-completed></progress-stage-completed>
@@ -48,13 +45,13 @@ export class ProfileConfig extends MobxLitElement {
   private renderName() {
     const handleNameInput = (e: Event) => {
       const name = (e.target as HTMLTextAreaElement).value;
-      this.participantService.updateProfile({ name });
+      this.participantService.updateProfile({name});
     };
 
     return html`
       <pr-textarea
-        label="Name"
-        placeholder="Name"
+        label="First name"
+        placeholder="This may be visible to other participants"
         variant="outlined"
         .value=${this.participantService.profile?.name}
         ?disabled=${!this.participantService.isCurrentStage()}
@@ -69,42 +66,47 @@ export class ProfileConfig extends MobxLitElement {
       const value = (e.target as HTMLTextAreaElement).value;
       this.customPronouns = value;
       if (isCustom()) {
-        this.participantService.updateProfile({ pronouns: value });
+        this.participantService.updateProfile({pronouns: value});
       }
     };
 
     const handlePronounsInput = (e: Event) => {
       const value = (e.target as HTMLInputElement).value;
       switch (value) {
-        case "1":
-          this.participantService.updateProfile({ pronouns: "she/her" });
+        case '1':
+          this.participantService.updateProfile({pronouns: 'she/her'});
           return;
-        case "2":
-          this.participantService.updateProfile({ pronouns: "he/him" });
+        case '2':
+          this.participantService.updateProfile({pronouns: 'he/him'});
           return;
-        case "3":
-          this.participantService.updateProfile({ pronouns: "they/them" });
+        case '3':
+          this.participantService.updateProfile({pronouns: 'they/them'});
           return;
         default:
-          this.participantService.updateProfile(
-            { pronouns: this.customPronouns }
-          );
+          this.participantService.updateProfile({
+            pronouns: this.customPronouns,
+          });
           return;
       }
     };
 
     const isMatch = (pronouns: string) => {
-      return this.participantService.profile?.pronouns?.toLowerCase() === pronouns;
-    }
+      return (
+        this.participantService.profile?.pronouns?.toLowerCase() === pronouns
+      );
+    };
 
     const isCustom = () => {
       const pronouns = this.participantService.profile?.pronouns?.toLowerCase();
-      if (pronouns === "she/her" || pronouns === "he/him"
-        || pronouns === "they/them") {
+      if (
+        pronouns === 'she/her' ||
+        pronouns === 'he/him' ||
+        pronouns === 'they/them'
+      ) {
         return false;
       }
       return pronouns !== null;
-    }
+    };
 
     return html`
       <div class="radio-question">
@@ -115,9 +117,10 @@ export class ProfileConfig extends MobxLitElement {
             name="group"
             value="1"
             aria-label="she/her"
-            ?checked=${isMatch("she/her")}
+            ?checked=${isMatch('she/her')}
             ?disabled=${!this.participantService.isCurrentStage()}
-            @change=${handlePronounsInput}>
+            @change=${handlePronounsInput}
+          >
           </md-radio>
           <label for="she">she/her</label>
         </div>
@@ -127,7 +130,7 @@ export class ProfileConfig extends MobxLitElement {
             name="group"
             value="2"
             aria-label="he/him"
-            ?checked=${isMatch("he/him")}
+            ?checked=${isMatch('he/him')}
             ?disabled=${!this.participantService.isCurrentStage()}
             @change=${handlePronounsInput}
           >
@@ -140,7 +143,7 @@ export class ProfileConfig extends MobxLitElement {
             name="group"
             value="3"
             aria-label="they/them"
-            ?checked=${isMatch("they/them")}
+            ?checked=${isMatch('they/them')}
             ?disabled=${!this.participantService.isCurrentStage()}
             @change=${handlePronounsInput}
           >
@@ -161,7 +164,9 @@ export class ProfileConfig extends MobxLitElement {
           <pr-textarea
             variant="outlined"
             placeholder="Add pronouns"
-            .value=${isCustom() ? this.participantService.profile?.pronouns : this.customPronouns}
+            .value=${isCustom()
+              ? this.participantService.profile?.pronouns
+              : this.customPronouns}
             ?disabled=${!this.participantService.isCurrentStage()}
             @change=${handleCustomPronouns}
           >
@@ -176,7 +181,7 @@ export class ProfileConfig extends MobxLitElement {
       const value = Number((e.target as HTMLInputElement).value);
       const avatarUrl = PROFILE_AVATARS[value];
 
-      this.participantService.updateProfile({ avatarUrl });
+      this.participantService.updateProfile({avatarUrl});
     };
 
     const renderAvatarRadio = (emoji: string, index: number) => {
@@ -201,7 +206,9 @@ export class ProfileConfig extends MobxLitElement {
       <div class="radio-question">
         <div class="title">Avatar</div>
         <div class="avatars-wrapper">
-          ${PROFILE_AVATARS.map((avatar, index) => renderAvatarRadio(avatar, index))}
+          ${PROFILE_AVATARS.map((avatar, index) =>
+            renderAvatarRadio(avatar, index)
+          )}
         </div>
       </div>
     `;
@@ -210,6 +217,6 @@ export class ProfileConfig extends MobxLitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "profile-config": ProfileConfig;
+    'profile-config': ProfileConfig;
   }
 }

--- a/lit/src/experiment-components/profile/profile_preview.ts
+++ b/lit/src/experiment-components/profile/profile_preview.ts
@@ -23,6 +23,7 @@ import {
 } from '@llm-mediation-experiments/utils';
 import {convertUnifiedTimestampToDate} from '../../shared/utils';
 
+import {PARTICIPANT_COMPLETION_TYPE} from '@llm-mediation-experiments/utils';
 import {styles} from './profile_preview.scss';
 
 /** Full participant profile preview */
@@ -116,7 +117,11 @@ export class ProfilePreview extends MobxLitElement {
 
     if (this.profile?.completedExperiment) {
       if (this.experimentService.experiment?.isLobby) {
-        if (this.profile?.transferConfig) {
+        if (
+          this.profile?.completionType ===
+            PARTICIPANT_COMPLETION_TYPE.SUCCESS ||
+          this.profile?.transferConfig
+        ) {
           color = 'success';
           text = 'completed';
         } else {

--- a/lit/src/experiment-components/profile/profile_preview.ts
+++ b/lit/src/experiment-components/profile/profile_preview.ts
@@ -86,6 +86,35 @@ export class ProfilePreview extends MobxLitElement {
     return nothing;
   }
 
+  renderBootButton() {
+    if (this.profile?.completedExperiment) {
+      return nothing;
+    }
+
+    const onBoot = () => {
+      this.participantService.setParticipant(
+        this.experimentService.id!,
+        this.profile?.privateId!
+      );
+      this.participantService.markExperimentCompleted(
+        PARTICIPANT_COMPLETION_TYPE.BOOTED_OUT
+      );
+      alert;
+    };
+
+    return html`
+      <pr-tooltip text="Kick participant out" position="BOTTOM_END">
+        <pr-icon-button
+          icon="block"
+          color="error"
+          variant="default"
+          @click=${onBoot}
+        >
+        </pr-icon-button>
+      </pr-tooltip>
+    `;
+  }
+
   renderDeleteButton() {
     if (!this.authService.canEdit) {
       return nothing;
@@ -116,21 +145,45 @@ export class ProfilePreview extends MobxLitElement {
     let text = 'in progress';
 
     if (this.profile?.completedExperiment) {
-      if (this.experimentService.experiment?.isLobby) {
-        if (
-          this.profile?.completionType ===
-            PARTICIPANT_COMPLETION_TYPE.SUCCESS ||
-          this.profile?.transferConfig
-        ) {
-          color = 'success';
-          text = 'completed';
-        } else {
-          color = 'tertiary';
-          text = 'timed out';
+      if (this.profile?.completionType) {
+        switch (this.profile?.completionType) {
+          case PARTICIPANT_COMPLETION_TYPE.SUCCESS:
+            color = 'success';
+            text = 'completed';
+            break;
+          case PARTICIPANT_COMPLETION_TYPE.ATTENTION_TIMEOUT:
+            color = 'tertiary';
+            text = 'failed attention';
+            break;
+          case PARTICIPANT_COMPLETION_TYPE.LOBBY_TIMEOUT:
+            color = 'tertiary';
+            text = 'lobby timeout';
+            break;
+          case PARTICIPANT_COMPLETION_TYPE.BOOTED_OUT:
+            color = 'tertiary';
+            text = 'booted out';
+            break;
+          default:
+            color = 'secondary';
+            text = 'undefined';
         }
       } else {
-        color = 'success';
-        text = 'completed';
+        if (this.experimentService.experiment?.isLobby) {
+          if (
+            this.profile?.completionType ===
+              PARTICIPANT_COMPLETION_TYPE.SUCCESS ||
+            this.profile?.transferConfig
+          ) {
+            color = 'success';
+            text = 'completed';
+          } else {
+            color = 'tertiary';
+            text = 'timed out';
+          }
+        } else {
+          color = 'success';
+          text = 'completed';
+        }
       }
     } else {
       if (curStageName.indexOf('Lobby') !== -1) {
@@ -266,6 +319,7 @@ export class ProfilePreview extends MobxLitElement {
           >
           </pr-icon-button>
         </pr-tooltip>
+        ${this.renderBootButton()}
         ${this.renderDeleteButton()}
       </div>
     `;

--- a/lit/src/experiment-components/reveal/reveal_preview.ts
+++ b/lit/src/experiment-components/reveal/reveal_preview.ts
@@ -2,7 +2,7 @@ import '../election/election_reveal';
 import '../footer/footer';
 import '../games/lost_at_sea/las_result';
 import '../progress/progress_stage_completed';
-import "../progress/progress_stage_waiting";
+import '../progress/progress_stage_waiting';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
 import {CSSResultGroup, html, nothing} from 'lit';
@@ -19,8 +19,9 @@ import {core} from '../../core/core';
 import {ExperimentService} from '../../services/experiment_service';
 import {ParticipantService} from '../../services/participant_service';
 
+import {unsafeHTML} from 'lit/directives/unsafe-html.js';
+import {convertMarkdownToHTML} from '../../shared/utils';
 import {styles} from './reveal_preview.scss';
-
 /** Reveal preview */
 @customElement('reveal-preview')
 export class RevealPreview extends MobxLitElement {
@@ -36,7 +37,7 @@ export class RevealPreview extends MobxLitElement {
       return nothing;
     }
 
-    const { ready, notReady } =
+    const {ready, notReady} =
       this.experimentService.getParticipantsReadyForStage(this.stage.id);
 
     if (notReady.length > 0) {
@@ -47,7 +48,9 @@ export class RevealPreview extends MobxLitElement {
     }
 
     return html`
-      <div class="description">${this.stage?.description}</div>
+      <div class="description">
+        ${unsafeHTML(convertMarkdownToHTML(this.stage?.description!))}
+      </div>
 
       <div class="stages-wrapper">
         ${this.stage?.stagesToReveal.map((stage) =>

--- a/lit/src/experiment-components/survey/survey_preview.ts
+++ b/lit/src/experiment-components/survey/survey_preview.ts
@@ -103,7 +103,7 @@ export class SurveyPreview extends MobxLitElement {
         <pr-textarea
           variant="outlined"
           placeholder="Type your response"
-          .value=${this.surveyService.textAnswers[question.id]}
+          .value=${this.surveyService.getTextAnswer(question.id)}
           ?disabled=${!this.participantService.isCurrentStage()}
           @change=${handleTextChange}
         >

--- a/lit/src/experiment-components/survey/survey_preview.ts
+++ b/lit/src/experiment-components/survey/survey_preview.ts
@@ -1,47 +1,44 @@
-import "../../pair-components/textarea";
+import '../../pair-components/textarea';
 
-import "../footer/footer";
-import "../progress/progress_stage_completed";
+import '../footer/footer';
+import '../progress/progress_stage_completed';
 
 import '@material/web/radio/radio.js';
 
-import { MobxLitElement } from "@adobe/lit-mobx";
-import { CSSResultGroup, html, nothing } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { classMap } from "lit/directives/class-map.js";
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
 
 import {
-  ITEMS,
-  ItemName,
-  QuestionConfig,
   MultipleChoiceItem,
-  MultipleChoiceQuestionConfig,
   MultipleChoiceQuestionAnswer,
+  MultipleChoiceQuestionConfig,
+  QuestionConfig,
   ScaleQuestionAnswer,
   ScaleQuestionConfig,
   SurveyQuestionKind,
   SurveyStageAnswer,
   SurveyStageConfig,
-  TextQuestionAnswer,
-  TextQuestionConfig
-} from "@llm-mediation-experiments/utils";
+  TextQuestionConfig,
+} from '@llm-mediation-experiments/utils';
 
-import { core } from "../../core/core";
-import { ParticipantService } from "../../services/participant_service";
-import { SurveyService } from "../../services/survey_service";
-
-import { styles } from "./survey_preview.scss";
+import {unsafeHTML} from 'lit/directives/unsafe-html.js';
+import {core} from '../../core/core';
+import {ParticipantService} from '../../services/participant_service';
+import {SurveyService} from '../../services/survey_service';
+import {convertMarkdownToHTML} from '../../shared/utils';
+import {styles} from './survey_preview.scss';
 
 /** Survey preview */
-@customElement("survey-preview")
+@customElement('survey-preview')
 export class SurveyPreview extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
   private readonly participantService = core.getService(ParticipantService);
   private readonly surveyService = core.getService(SurveyService);
 
-  @property() stage: SurveyStageConfig|null = null;
-  @property() answer: SurveyStageAnswer|null = null;
+  @property() stage: SurveyStageConfig | null = null;
+  @property() answer: SurveyStageAnswer | null = null;
 
   override render() {
     if (!this.stage) {
@@ -61,16 +58,19 @@ export class SurveyPreview extends MobxLitElement {
       }
       // Confirm that all text answers are completed on frontend
       return this.surveyService.isAllTextAnswersValid();
-    }
+    };
 
-    const descriptionContent = this.stage.description ? html`<div class="description">${this.stage.description}</div>` : nothing;
+    const descriptionContent = this.stage.description
+      ? html`<div class="description">
+          ${unsafeHTML(convertMarkdownToHTML(this.stage.description))}
+        </div>`
+      : nothing;
 
     return html`
       ${descriptionContent}
-      
+
       <div class="questions-wrapper">
-        ${this.stage.questions.map(question =>
-        this.renderQuestion(question))}
+        ${this.stage.questions.map((question) => this.renderQuestion(question))}
       </div>
       <stage-footer .disabled=${!questionsComplete()}>
         <progress-stage-completed></progress-stage-completed>
@@ -116,7 +116,9 @@ export class SurveyPreview extends MobxLitElement {
     return html`
       <div class="radio-question">
         <div class="title">${question.questionText}</div>
-        ${question.options.map(option => this.renderRadioButton(option, question.id))}
+        ${question.options.map((option) =>
+          this.renderRadioButton(option, question.id)
+        )}
       </div>
     `;
   }
@@ -124,7 +126,10 @@ export class SurveyPreview extends MobxLitElement {
   private isMultipleChoiceMatch(questionId: number, choiceId: number) {
     const questionAnswer = this.answer?.answers[questionId];
 
-    if (questionAnswer && questionAnswer.kind === SurveyQuestionKind.MultipleChoice) {
+    if (
+      questionAnswer &&
+      questionAnswer.kind === SurveyQuestionKind.MultipleChoice
+    ) {
       return questionAnswer.choice === choiceId;
     }
     return false;
@@ -138,8 +143,8 @@ export class SurveyPreview extends MobxLitElement {
       const answer: MultipleChoiceQuestionAnswer = {
         id: questionId,
         kind: SurveyQuestionKind.MultipleChoice,
-        choice
-      }
+        choice,
+      };
       this.participantService.updateSurveyStage(
         this.participantService.profile!.currentStageId,
         [answer]
@@ -164,7 +169,7 @@ export class SurveyPreview extends MobxLitElement {
   }
 
   private renderScaleQuestion(question: ScaleQuestionConfig) {
-    const scale = [...Array(10).keys()].map(n => n + 1);
+    const scale = [...Array(10).keys()].map((n) => n + 1);
 
     return html`
       <div class="question">
@@ -174,7 +179,7 @@ export class SurveyPreview extends MobxLitElement {
           <div>${question.upperBound}</div>
         </div>
         <div class="scale values">
-          ${scale.map(num => this.renderScaleRadioButton(question, num))}
+          ${scale.map((num) => this.renderScaleRadioButton(question, num))}
         </div>
       </div>
     `;
@@ -198,7 +203,7 @@ export class SurveyPreview extends MobxLitElement {
       const answer: ScaleQuestionAnswer = {
         id: question.id,
         kind: SurveyQuestionKind.Scale,
-        score
+        score,
       };
 
       this.participantService.updateSurveyStage(
@@ -227,6 +232,6 @@ export class SurveyPreview extends MobxLitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "survey-preview": SurveyPreview;
+    'survey-preview': SurveyPreview;
   }
 }

--- a/lit/src/experiment-components/tos/tos_preview.ts
+++ b/lit/src/experiment-components/tos/tos_preview.ts
@@ -1,32 +1,32 @@
-import "../../pair-components/icon_button";
+import '../../pair-components/icon_button';
 
-import "../footer/footer";
-import "../progress/progress_stage_completed";
+import '../footer/footer';
+import '../progress/progress_stage_completed';
 
-import "@material/web/checkbox/checkbox.js";
-import * as sanitizeHtml from "sanitize-html";
+import '@material/web/checkbox/checkbox.js';
+import * as sanitizeHtml from 'sanitize-html';
 
-import { MobxLitElement } from "@adobe/lit-mobx";
-import { CSSResultGroup, html, nothing } from "lit";
-import { customElement, property } from "lit/decorators.js";
-import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 
-import { TermsOfServiceStageConfig } from "@llm-mediation-experiments/utils";
-import { Timestamp } from "firebase/firestore";
+import {TermsOfServiceStageConfig} from '@llm-mediation-experiments/utils';
+import {Timestamp} from 'firebase/firestore';
 
-import { core } from "../../core/core";
-import { ParticipantService } from "../../services/participant_service";
-
-import { styles } from "./tos_preview.scss";
+import {core} from '../../core/core';
+import {ParticipantService} from '../../services/participant_service';
+import {convertMarkdownToHTML} from '../../shared/utils';
+import {styles} from './tos_preview.scss';
 
 /** TOS preview */
-@customElement("tos-preview")
+@customElement('tos-preview')
 export class TOSPreview extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
   private readonly participantService = core.getService(ParticipantService);
 
-  @property() stage: TermsOfServiceStageConfig|null = null;
+  @property() stage: TermsOfServiceStageConfig | null = null;
 
   override render() {
     if (!this.stage || this.participantService.profile === undefined) {
@@ -38,17 +38,19 @@ export class TOSPreview extends MobxLitElement {
     const timestamp = this.participantService.profile?.acceptTosTimestamp;
     const handleTOSClick = () => {
       const acceptTosTimestamp = timestamp ? null : Timestamp.now();
-      this.participantService.updateProfile({ acceptTosTimestamp });
+      this.participantService.updateProfile({acceptTosTimestamp});
     };
 
-    const descriptionContent = this.stage.description ? html`<div class="description">${this.stage.description}</div>` : nothing;
+    const descriptionContent = this.stage.description
+      ? html`<div class="description">
+          ${unsafeHTML(convertMarkdownToHTML(this.stage.description))}
+        </div>`
+      : nothing;
 
     return html`
       ${descriptionContent}
-      
-      <div class="tos-wrapper">
-        ${unsafeHTML(cleanHTML)}
-      </div>
+
+      <div class="tos-wrapper">${unsafeHTML(cleanHTML)}</div>
       <div class="ack-wrapper">
         <label class="checkbox-wrapper">
           <md-checkbox
@@ -62,8 +64,9 @@ export class TOSPreview extends MobxLitElement {
           I accept the Terms of Service
         </label>
         <div class="timestamp-wrapper">
-          ${timestamp ?
-            `Accepted at ${new Date(timestamp.seconds * 1000)}` : nothing}
+          ${timestamp
+            ? `Accepted at ${new Date(timestamp.seconds * 1000)}`
+            : nothing}
         </div>
       </div>
       <stage-footer .disabled=${timestamp === null}>
@@ -75,6 +78,6 @@ export class TOSPreview extends MobxLitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "tos-preview": TOSPreview;
+    'tos-preview': TOSPreview;
   }
 }

--- a/lit/src/sass/_common.scss
+++ b/lit/src/sass/_common.scss
@@ -143,6 +143,11 @@
       background: var(--md-sys-color-progress);
     }
 
+    &.timeout {
+      background: var(--md-sys-color-error);
+      width: 100%;
+    }
+
     &.completed {
       background: var(--md-sys-color-success);
       width: 100%;

--- a/lit/src/services/experimenter_service.ts
+++ b/lit/src/services/experimenter_service.ts
@@ -26,10 +26,10 @@ import {
 } from '../shared/callables';
 import {collectSnapshotWithId} from '../shared/utils';
 
-import { FirebaseService } from "./firebase_service";
-import { ParticipantService } from "./participant_service";
-import { RouterService } from "./router_service";
-import { Service } from "./service";
+import {FirebaseService} from './firebase_service';
+import {ParticipantService} from './participant_service';
+import {RouterService} from './router_service';
+import {Service} from './service';
 
 interface ServiceProvider {
   firebaseService: FirebaseService;
@@ -226,6 +226,7 @@ export class ExperimenterService extends Service {
     const numberOfMaxParticipants = experiment.numberOfMaxParticipants ?? 0;
     const waitForAllToStart = experiment.waitForAllToStart ?? false;
     const prolificRedirectCode = experiment.prolificRedirectCode ?? '';
+    const attentionCheckParams = experiment.attentionCheckParams ?? {};
 
     return createExperimentCallable(this.sp.firebaseService.functions, {
       type: 'experiments',
@@ -240,6 +241,7 @@ export class ExperimenterService extends Service {
         numberOfMaxParticipants,
         waitForAllToStart,
         prolificRedirectCode,
+        attentionCheckParams,
       },
       stages,
     });
@@ -259,6 +261,7 @@ export class ExperimenterService extends Service {
     const numberOfMaxParticipants = experiment.numberOfMaxParticipants ?? 0;
     const waitForAllToStart = experiment.waitForAllToStart ?? false;
     const prolificRedirectCode = experiment.prolificRedirectCode ?? '';
+    const attentionCheckParams = experiment.attentionCheckParams ?? {};
 
     return createExperimentCallable(this.sp.firebaseService.functions, {
       type: 'templates',
@@ -273,6 +276,7 @@ export class ExperimenterService extends Service {
         numberOfMaxParticipants,
         waitForAllToStart,
         prolificRedirectCode,
+        attentionCheckParams,
       },
       stages,
     });
@@ -309,7 +313,9 @@ export class ExperimenterService extends Service {
     try {
       // Create transfer participant in new experiment
       const response = await this.createParticipant(
-        newExperimentId, participant, currentExperimentId
+        newExperimentId,
+        participant,
+        currentExperimentId
       );
 
       // Mark participant as transferred in old experiment

--- a/lit/src/services/participant_service.ts
+++ b/lit/src/services/participant_service.ts
@@ -6,7 +6,6 @@ import {
   QuestionAnswer,
   StageAnswer,
   StageKind,
-  Votes,
   lookupTable,
 } from '@llm-mediation-experiments/utils';
 import {
@@ -228,14 +227,14 @@ export class ParticipantService extends Service {
   /** Update a vote for leader stage for this participant
    * @rights Participant
    */
-  async updateVoteForLeaderStage(stageId: string, votes: Votes) {
+  async updateVoteForLeaderStage(stageId: string, rankings: string[]) {
     return updateStageCallable(this.sp.firebaseService.functions, {
       experimentId: this.experimentId!,
       participantId: this.participantId!,
       stageId,
       stage: {
         kind: StageKind.VoteForLeader,
-        votes,
+        rankings,
       },
     });
   }

--- a/lit/src/services/survey_service.ts
+++ b/lit/src/services/survey_service.ts
@@ -85,13 +85,13 @@ export class SurveyService extends Service {
   }
 
   async saveTextAnswers() {
-    for (const key in Object.keys(this.textAnswers)) {
+    for (const key of Object.keys(this.textAnswers)) {
       const id = Number(key);
       const answer: TextQuestionAnswer = {
         id,
         kind: SurveyQuestionKind.Text,
         answerText: this.textAnswers[id] ?? '',
-      }
+      };
       await this.sp.participantService.updateSurveyStage(
         this.sp.participantService.profile!.currentStageId,
         [answer]

--- a/lit/src/services/survey_service.ts
+++ b/lit/src/services/survey_service.ts
@@ -31,7 +31,9 @@ export class SurveyService extends Service {
   @observable experimentId: string | null = null;
   @observable participantId: string | null = null;
   @observable stageId = '';
-  @observable textAnswers: Record<number, string> = {};
+
+  // Map of stage ID to map of text answers
+  @observable textAnswersMap: Record<string, Record<number, string>> = {};
 
   // Loading
   @observable areAnswersLoading = false;
@@ -55,24 +57,27 @@ export class SurveyService extends Service {
   loadSurveyAnswers() {
     const stage = (this.sp.experimentService.getStage(this.stageId) as SurveyStageConfig);
     const answer = (this.sp.participantService.stageAnswers[this.stageId] as SurveyStageAnswer);
-    this.textAnswers = {};
+
+    const textAnswers: Record<number, string> = {};
 
     if (stage) {
       for (const question of stage.questions.filter(question => question.kind === SurveyQuestionKind.Text)) {
-        this.textAnswers[question.id] = answer ? (
+        textAnswers[question.id] = answer ? (
           answer.answers[question.id] as TextQuestionAnswer
         )?.answerText ?? '' : '';
       }
     }
+
+    this.textAnswersMap[stage.id] = textAnswers;
     this.areAnswersLoading = false;
   }
 
   updateTextAnswer(id: number, answer: string) {
-    this.textAnswers[id] = answer;
+    this.textAnswersMap[this.stageId][id] = answer;
   }
 
   isAllTextAnswersValid() {
-    for (const answer of Object.values(this.textAnswers)) {
+    for (const answer of Object.values(this.textAnswersMap[this.stageId])) {
       if (answer === '') {
         return false;
       }
@@ -81,16 +86,20 @@ export class SurveyService extends Service {
   }
 
   getNumTextAnswers() {
-    return Object.keys(this.textAnswers).length;
+    return Object.keys(this.textAnswersMap[this.stageId]).length;
+  }
+
+  getTextAnswer(questionId: number) {
+    return this.textAnswersMap[this.stageId][questionId];
   }
 
   async saveTextAnswers() {
-    for (const key of Object.keys(this.textAnswers)) {
+    for (const key of Object.keys(this.textAnswersMap[this.stageId])) {
       const id = Number(key);
       const answer: TextQuestionAnswer = {
         id,
         kind: SurveyQuestionKind.Text,
-        answerText: this.textAnswers[id] ?? '',
+        answerText: this.textAnswersMap[this.stageId][id] ?? '',
       };
       await this.sp.participantService.updateSurveyStage(
         this.sp.participantService.profile!.currentStageId,

--- a/lit/src/shared/lost_at_sea/constants.ts
+++ b/lit/src/shared/lost_at_sea/constants.ts
@@ -208,12 +208,15 @@ export const LAS_REVEAL_INFO = `An explanation of the results can be found [here
 
 export const LAS_PAYMENT_INSTRUCTIONS = [
   '## Part 1 Payment:',
-  'Your payment for Part 1 includes a fixed fee of £3 and a bonus. The bonus is determined by randomly selecting one question from Part 1. If your answer to this question is correct, you earn £2; otherwise, you earn £0. Below, you can see which question was selected and whether you received the bonus.',
+  'Your payment for Part 1 includes a fixed fee of £3 and a bonus. The bonus is determined by randomly selecting one question from Part 1. If your answer to this question is correct, you earn £2; otherwise, you earn £0.',
   '\n\n## Payment for Parts 2 and 3:',
   'Your payment for Parts 2 and 3 includes a fixed fee of £6 and a bonus. The bonus is determined by randomly selecting either Part 2 or Part 3.',
   '* If Part 2 is selected: One question is randomly chosen from Part 2. You earn £2 if your answer is correct, and £0 otherwise.',
   '* If Part 3 is selected: One question is randomly chosen from Part 3, with only the leader’s answer counting. You earn £2 if the leader’s answer is correct, and £0 otherwise.',
-  'Below, you can see which part and question were selected and whether you received the bonus.'
+];
+export const LAS_PAYMENT_INSTRUCTIONS_ALL = [
+  ...LAS_PAYMENT_INSTRUCTIONS,
+  'On the next page, you can see which part and question were selected and whether you received the bonus.',
 ];
 
 export const LAS_FINAL_SURVEY: QuestionConfig[] = [

--- a/lit/src/shared/lost_at_sea/constants.ts
+++ b/lit/src/shared/lost_at_sea/constants.ts
@@ -18,7 +18,7 @@ export const LAS_TOS = [
   "By clicking 'Next,' you accept these terms and proceed with the study.",
 ];
 
-export const LAS_INTRO_DESCRIPTION = `This experiment should take an estimated X minutes.`;
+export const LAS_INTRO_DESCRIPTION = `This experiment is part of a research project that explores human decisions in various online environments. You will complete different tasks, and answer questions. You may also interact with others during the experiment.`;
 export const LAS_INTRO_INFO_LINES = [
   'You will receive a fixed fee of $x for your participation. The experiment also gives you the opportunity to earn a $x bonus, based on your decisions. We will explain precisely how your bonus is determined later.',
   'At the end of the experiment, you will be redirected to a waiting page. This waiting time is part of the experiment and has been factored into your payment. **You will not be approved for the payout if you do not remain on this waiting page for the full requested duration**.',
@@ -117,6 +117,7 @@ export const LAS_GROUP_DISCUSSION_INSTRUCTIONS = [
   '\n\n## Purpose of the Discussion:',
   '* **Debate Object Utility:** The goal is to debate the usefulness of the items using the most relevant and well-developed arguments possible. The more arguments you gather, the more useful it will be for Part 3, where different pairs of the same items will be evaluated. Whoever the leader is, knowing the best arguments will help them make the best decisions in Part 3.',
   '* **Gauge Abilities:** You can see this discussion as an opportunity to assess the abilities of your team members, as you will later vote for a representative whose performance will determine your payout.',
+  '\n\n*Remember, you do not need to agree on which item is most useful; the goal is to present and discuss the strongest arguments for each item.*',
   '\n\nPlease keep these guidelines in mind as you engage in the discussion. Your active participation and thoughtful contributions are crucial for the success of the experiment.',
 ];
 
@@ -194,7 +195,7 @@ export const LAS_PART_3_INSTRUCTIONS = [
 ];
 
 export const LAS_GROUP_CHAT_DESCRIPTION =
-  'Discuss your responses to the previous task with your teammates. Take this opportunity to gauge the abilities of your crewmembers, as you will later vote for a representative whose performance will determine your payout.';
+  'Discuss your responses to the previous task with your teammates. Take this opportunity to gauge the abilities of your crewmembers, as you will later vote for a representative whose performance will determine your payout.\n\n*Remember, you do not need to agree on which item is most useful; the goal is to present and discuss the strongest arguments for each item.*';
 
 export const LAS_REDO_TASK_DESCRIPTION = `Have your opinions on the ordering of the items pairs changed following the discussion with crewmates? Now, please update your initial responses.`;
 

--- a/lit/src/shared/lost_at_sea/constants.ts
+++ b/lit/src/shared/lost_at_sea/constants.ts
@@ -41,7 +41,7 @@ export const LAS_SCENARIO_REMINDER =
   'Here is a reminder of the scenario:\n\nYou and three friends are on a yacht trip across the Atlantic. A fire breaks out, and the skipper and crew are lost. The yacht is sinking, and your location is unclear.\nYou have saved 10 items, a life raft, and a box of matches.\n\nEvaluate the relative importance of items in each presented pair by selecting the one you believe is most useful. You can earn $X per correct answer if that question is drawn to determine your payoff.';
 
 export const LAS_WTL_DESCRIPTION =
-  'Thank you for completing the task.\n\nNow, imagine that you are no longer alone but part of a group of four people. Your group must elect a leader whose role is to answer on behalf of the group the same types of questions you have just seen. In this scenario, the leader is the only one who chooses the most useful items for survival from pairs, and their answers determine the payment for each member of the group.\n\nHow interested would you be in taking on the leader’s role described above? Please choose a number from 1 to 10, with 1 meaning that you would very much like to become the leader, and 10 meaning not at all.';
+  'Thank you for completing the task.\n\nNow, imagine that you are no longer alone but part of a group of four people. Your group must elect a leader whose role is to answer on behalf of the group the same types of questions you have just seen. In this scenario, the leader is the only one who chooses the most useful items for survival from pairs, and their answers determine the payment for each member of the group.';
 
 export const LAS_WTL_SURVEY: QuestionConfig[] = [
   {
@@ -122,7 +122,7 @@ export const LAS_GROUP_DISCUSSION_INSTRUCTIONS = [
 
 export const LAS_UPDATE_INSTRUCTIONS = [
   'You are now given a chance to update the choices you previously made in Part 1. You can choose to update your previous answers or provide the same answers again.',
-  "\n\nIf a question from Part 2 is selected to determine your final payoff, the answers you give below will be evaluated in the same way as in Part 1. Your answers will be compared to a panel of experts' solutions, and you will earn $X if your answer is correct, and $0 otherwise.",
+  "\n\nIf a question from Part 2 is selected to determine your final payoff, the answers you give on the next screen will be evaluated in the same way as in Part 1. Your answers will be compared to a panel of experts' solutions, and you will earn $X if your answer is correct, and $0 otherwise.",
   '\n\n*Please note that Part 1 and Part 2 of the experiment are independent. Changing answers here will not impact the answers you provided in Part 1.*',
 ];
 

--- a/lit/src/shared/lost_at_sea/utils.ts
+++ b/lit/src/shared/lost_at_sea/utils.ts
@@ -27,7 +27,6 @@ import {
 import {
   ITEMS_SET_1,
   ITEMS_SET_2,
-  ITEMS_SET_3,
   LAS_FINAL_SURVEY,
   LAS_FINAL_SURVEY_DESCRIPTION,
   LAS_GROUP_CHAT_DESCRIPTION,
@@ -175,7 +174,7 @@ function getPart2PreElectionStages(): StageConfig[] {
   );
 
   // Individual task.
-  const INDIVIDUAL_QUESTIONS: LostAtSeaQuestion[] = ITEMS_SET_3.map(
+  const INDIVIDUAL_QUESTIONS: LostAtSeaQuestion[] = ITEMS_SET_1.map(
     (pair, index) => getQuestionFromPair(pair, index)
   );
   const redoTask = createLostAtSeaSurveyStage({
@@ -232,13 +231,12 @@ function getPart2PostElectionAndPart3Stages(): StageConfig[] {
     })
   );
 
-  // Individual task.
-  const INDIVIDUAL_QUESTIONS: LostAtSeaQuestion[] = ITEMS_SET_2.map(
-    (pair, index) => getQuestionFromPair(pair, index)
+  const LEADER_QUESTIONS: LostAtSeaQuestion[] = ITEMS_SET_2.map((pair, index) =>
+    getQuestionFromPair(pair, index)
   );
   const leaderTask = createLostAtSeaSurveyStage({
     name: 'Leader task',
-    questions: INDIVIDUAL_QUESTIONS,
+    questions: LEADER_QUESTIONS,
     popupText: LAS_SCENARIO_REMINDER,
   });
   stages.push(leaderTask);

--- a/lit/src/shared/lost_at_sea/utils.ts
+++ b/lit/src/shared/lost_at_sea/utils.ts
@@ -42,6 +42,7 @@ import {
   LAS_LEADER_REVEAL_DESCRIPTION,
   LAS_PART_3_INSTRUCTIONS,
   LAS_PAYMENT_INSTRUCTIONS,
+  LAS_PAYMENT_INSTRUCTIONS_ALL,
   LAS_PE2_SURVEY,
   LAS_PE_DESCRIPTION,
   LAS_PE_SURVEY,
@@ -261,7 +262,7 @@ export function getFinalStages(): StageConfig[] {
   stages.push(
     createInfoStage({
       name: 'Payment breakdown',
-      infoLines: LAS_PAYMENT_INSTRUCTIONS,
+      infoLines: LAS_PAYMENT_INSTRUCTIONS_ALL,
     })
   );
 
@@ -269,6 +270,7 @@ export function getFinalStages(): StageConfig[] {
   stages.push(
     createPayoutStage({
       name: 'Final payoff',
+      popupText: LAS_PAYMENT_INSTRUCTIONS.join('\n'),
       payouts: [
         {
           name: 'Part 1 payoff',
@@ -279,7 +281,7 @@ export function getFinalStages(): StageConfig[] {
               strategy: PayoutItemStrategy.ChooseOne,
               surveyStageId: initialTaskId,
               currencyAmountPerQuestion: 2,
-              fixedCurrencyAmount: 0,
+              fixedCurrencyAmount: 3,
             },
           ],
         },

--- a/lit/src/shared/utils.ts
+++ b/lit/src/shared/utils.ts
@@ -215,7 +215,13 @@ export function getElectionStages(stages: StageConfig[]) {
 }
 
 /** Use micromark to convert Git-flavored markdown to HTML. */
-export function convertMarkdownToHTML(markdown: string, sanitize = true) {
+export function convertMarkdownToHTML(
+  markdown: string | null,
+  sanitize = true
+) {
+  if (!markdown) {
+    return '';
+  }
   const html = micromark(markdown, {
     allowDangerousHtml: !sanitize,
     extensions: [gfm()],

--- a/lit/src/shared/utils.ts
+++ b/lit/src/shared/utils.ts
@@ -259,5 +259,5 @@ export function convertUnifiedTimestampToDate(timestamp: UnifiedTimestamp) {
  * including the document Firestore ID within the field with the given key.
  */
 export function collectSnapshotWithId<T>(snapshot: Snapshot, idKey: keyof T) {
-  return snapshot.docs.map((doc) => ({ [idKey]: doc.id, ...doc.data() }) as T);
+  return snapshot.docs.map((doc) => ({[idKey]: doc.id, ...doc.data()} as T));
 }

--- a/utils/src/types/experiments.types.ts
+++ b/utils/src/types/experiments.types.ts
@@ -10,6 +10,12 @@ export interface Experimenter {
   displayName: string;
 }
 
+export interface AttentionCheckParams {
+  waitSeconds?: number;
+  popupSeconds?: number;
+  prolificAttentionFailRedirectCode?: string;
+}
+
 /** Experiment metadata */
 export interface Experiment {
   id: string;
@@ -26,7 +32,7 @@ export interface Experiment {
   numberOfMaxParticipants: number;
   waitForAllToStart: boolean;
   prolificRedirectCode?: string; // If specified, will handle Prolific routing.
-
+  attentionCheckParams?: AttentionCheckParams;
   // Ordered list of stage IDs
   stageIds: string[];
 

--- a/utils/src/types/participants.types.ts
+++ b/utils/src/types/participants.types.ts
@@ -4,6 +4,14 @@
 
 import { UnifiedTimestamp } from './api.types';
 
+export enum PARTICIPANT_COMPLETION_TYPE {
+  SUCCESS = 'SUCCESS',
+  // Failed to transfer to a lobby within the designated time.
+  LOBBY_TIMEOUT = 'LOBBY_FAIL',
+  // Failed to clear the attention check within the designated time.
+  ATTENTION_TIMEOUT = 'ATTENTION_FAIL',
+}
+
 /** Profile data that is modifiable by the participant */
 export interface ParticipantProfileBase {
   pronouns: string | null;
@@ -12,7 +20,7 @@ export interface ParticipantProfileBase {
 
   acceptTosTimestamp: UnifiedTimestamp | null;
   completedExperiment: UnifiedTimestamp | null;
-
+  completionType: PARTICIPANT_COMPLETION_TYPE | null;
   prolificId: string | null;
 }
 

--- a/utils/src/types/participants.types.ts
+++ b/utils/src/types/participants.types.ts
@@ -10,6 +10,8 @@ export enum PARTICIPANT_COMPLETION_TYPE {
   LOBBY_TIMEOUT = 'LOBBY_FAIL',
   // Failed to clear the attention check within the designated time.
   ATTENTION_TIMEOUT = 'ATTENTION_FAIL',
+  // Booted from the experiment.
+  BOOTED_OUT = 'BOOTED_OUT',
 }
 
 /** Profile data that is modifiable by the participant */

--- a/utils/src/types/stages.types.ts
+++ b/utils/src/types/stages.types.ts
@@ -5,7 +5,6 @@ import { LostAtSeaQuestion, LostAtSeaQuestionAnswer } from './lost_at_sea.types'
 import { MediatorConfig } from './mediator.types';
 import { PayoutBundle, PayoutCurrency, ScoringBundle } from './payout.types';
 import { QuestionAnswer, QuestionConfig } from './questions.types';
-import { Votes } from './votes.types';
 
 export enum StageKind {
   Info = 'info',
@@ -118,7 +117,8 @@ export interface LostAtSeaSurveyStageAnswer extends BaseStageAnswer {
 export interface VoteForLeaderStageAnswer extends BaseStageAnswer {
   kind: StageKind.VoteForLeader;
 
-  votes: Votes;
+  // Ordered list of preferred participant leaders (by public IDs)
+  rankings: string[];
 }
 
 export interface ChatStageAnswer {
@@ -153,7 +153,7 @@ export interface GroupChatStagePublicData extends BasePublicStageData {
 export interface VoteForLeaderStagePublicData extends BasePublicStageData {
   kind: StageKind.VoteForLeader;
 
-  participantvotes: Record<string, Votes>; // Participant public id => votes of this participant
+  participantRankings: Record<string, string[]>; // Participant public id => ordered rankings
   currentLeader: string | null; // Updated automatically after each vote
 }
 

--- a/utils/src/utils/algebraic.utils.ts
+++ b/utils/src/utils/algebraic.utils.ts
@@ -70,3 +70,56 @@ let _uniqueId = 0;
 export const uniqueId = (prefix?: string) => {
   return prefix ? `${prefix}${_uniqueId++}` : `${_uniqueId++}`;
 };
+
+/**
+ * Runs a Condorcet election on a set of rankings.
+ */
+export function getCondorcetElectionWinner(rankings: Record<string, string[]>) {
+  const participants = Object.keys(rankings);
+  const wins: Record<string, number> = {};
+
+  // Initialize win counts
+  participants.forEach((participant) => {
+    wins[participant] = 0;
+  });
+
+  // Compare each participant against each other
+  for (let i = 0; i < participants.length; i++) {
+    for (let j = i + 1; j < participants.length; j++) {
+      const p1 = participants[i];
+      const p2 = participants[j];
+
+      let p1Wins = 0;
+      let p2Wins = 0;
+
+      // Determine the winner in each ranking
+      participants.forEach((participant) => {
+        const ranking = rankings[participant];
+        if (ranking.indexOf(p1) < ranking.indexOf(p2)) {
+          p1Wins++;
+        } else {
+          p2Wins++;
+        }
+      });
+
+      // Update the win counts
+      if (p1Wins > p2Wins) {
+        wins[p1]++;
+      } else {
+        wins[p2]++;
+      }
+    }
+  }
+
+  // Find the participant with the most wins
+  let winner = null;
+  let maxWins = -1;
+  for (const participant in wins) {
+    if (wins[participant] > maxWins) {
+      maxWins = wins[participant];
+      winner = participant;
+    }
+  }
+
+  return winner;
+}

--- a/utils/src/validation/experiments.validation.ts
+++ b/utils/src/validation/experiments.validation.ts
@@ -53,6 +53,11 @@ export const ExperimentDeletionData = Type.Object(
 
 export type ExperimentDeletionData = Static<typeof ExperimentDeletionData>;
 
+const AttentionCheckParamsSchema = Type.Object({
+  waitSeconds: Type.Optional(Type.Number({ minimum: 0 })),
+  popupSeconds: Type.Optional(Type.Number({ minimum: 0 })),
+  prolificAttentionFailRedirectCode: Type.Optional(Type.String()),
+});
 /**
  * Generic experiment or template creation data
  */
@@ -74,6 +79,7 @@ export const ExperimentCreationData = Type.Object(
         numberOfMaxParticipants: Type.Optional(Type.Number({ minimum: 0 })),
         waitForAllToStart: Type.Boolean(),
         prolificRedirectCode: Type.Optional(Type.String()),
+        attentionCheckParams: Type.Optional(AttentionCheckParamsSchema),
       },
       strict,
     ),

--- a/utils/src/validation/stages.validation.ts
+++ b/utils/src/validation/stages.validation.ts
@@ -3,7 +3,6 @@ import { ChatContext, MediatorKind } from '../types/mediator.types';
 import { PayoutCurrency } from '../types/payout.types';
 import { SurveyQuestionKind } from '../types/questions.types';
 import { BaseStageConfig, StageConfig, StageKind } from '../types/stages.types';
-import { Vote } from '../types/votes.types';
 import { ChatAboutItemsConfigData, SimpleChatConfigData } from './chats.validation';
 import {
   LostAtSeaQuestionData,
@@ -246,15 +245,7 @@ export const LostAtSeaSurveyStageAnswerData = Type.Object(
 export const VoteForLeaderStageAnswerData = Type.Object(
   {
     kind: Type.Literal(StageKind.VoteForLeader),
-    votes: Type.Record(
-      Type.String({ minLength: 1 }),
-      Type.Union([
-        Type.Literal(Vote.Positive),
-        Type.Literal(Vote.Neutral),
-        Type.Literal(Vote.Negative),
-        Type.Literal(Vote.NotRated),
-      ]),
-    ),
+    rankings: Type.Array(Type.String()),
   },
   strict,
 );


### PR DESCRIPTION
Fixes #154 

Instead of old voting system (positive, negative, neutral), enable users to drag and drop other participants into a ranked list. Use this ranked list to calculate the current leader.

Note that this updates VoteForLeader answer to contain a `ranking` field (with ordered list of participant IDs) instead of `votes` (legacy map of participant IDs to enum vote values).