### PR TITLE
Add transfer stage to experiments

### DIFF
--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -104,6 +104,10 @@ export class ExperimentBuilder extends MobxLitElement {
           <base-stage-editor .stage=${stage}></base-stage-editor>
           <tos-editor .stage=${stage}></tos-editor>
         `;
+      case StageKind.TRANSFER:
+        return html`
+          <base-stage-editor .stage=${stage}></base-stage-editor>
+        `;
       default:
         return nothing;
     }

--- a/frontend/src/components/experiment_builder/experiment_builder.ts
+++ b/frontend/src/components/experiment_builder/experiment_builder.ts
@@ -3,6 +3,7 @@ import '../stages/info_editor';
 import '../stages/survey_editor';
 import '../stages/survey_editor_menu';
 import '../stages/tos_editor';
+import '../stages/transfer_editor';
 import './experiment_builder_nav';
 import './experiment_settings_editor';
 import './stage_builder_dialog';
@@ -107,6 +108,7 @@ export class ExperimentBuilder extends MobxLitElement {
       case StageKind.TRANSFER:
         return html`
           <base-stage-editor .stage=${stage}></base-stage-editor>
+          <transfer-editor .stage=${stage}></transfer-editor>
         `;
       default:
         return nothing;

--- a/frontend/src/components/experiment_builder/stage_builder_dialog.ts
+++ b/frontend/src/components/experiment_builder/stage_builder_dialog.ts
@@ -17,7 +17,8 @@ import {
   createInfoStage,
   createProfileStage,
   createSurveyStage,
-  createTOSStage
+  createTOSStage,
+  createTransferStage
 } from '@deliberation-lab/utils';
 
 import {styles} from './stage_builder_dialog.scss';
@@ -54,6 +55,7 @@ export class StageBuilderDialog extends MobxLitElement {
       <div class="card-gallery-wrapper">
         ${this.renderTOSCard()}
         ${this.renderInfoCard()}
+        ${this.renderTransferCard()}
         ${this.renderProfileCard()}
         ${this.renderSurveyCard()}
         ${this.renderChatCard()}
@@ -140,6 +142,23 @@ export class StageBuilderDialog extends MobxLitElement {
         <div class="title">Profile</div>
         <div>
           Set participant profile
+        </div>
+      </div>
+    `;
+  }
+
+  private renderTransferCard() {
+    const addStage = () => {
+      this.experimentEditor.addStage(createTransferStage());
+      this.experimentEditor.toggleStageBuilderDialog();
+    }
+
+    return html`
+      <div class="card" @click=${addStage}>
+        <div class="title">Transfer</div>
+        <div>
+          During transfer stage, assign participants to different cohorts
+          in your experiment while participants wait
         </div>
       </div>
     `;

--- a/frontend/src/components/experiment_manager/participant_summary.ts
+++ b/frontend/src/components/experiment_manager/participant_summary.ts
@@ -9,11 +9,13 @@ import {classMap} from 'lit/directives/class-map.js';
 
 import {core} from '../../core/core';
 import {ExperimentManager} from '../../services/experiment.manager';
+import {ExperimentService} from '../../services/experiment.service';
 import {Pages, RouterService} from '../../services/router.service';
 
 import {
   ParticipantProfileExtended,
-  ParticipantStatus
+  ParticipantStatus,
+  StageKind
 } from '@deliberation-lab/utils';
 
 import {styles} from './participant_summary.scss';
@@ -24,6 +26,7 @@ export class ParticipantSummary extends MobxLitElement {
   static override styles: CSSResultGroup = [styles];
 
   private readonly experimentManager = core.getService(ExperimentManager);
+  private readonly experimentService = core.getService(ExperimentService);
   private readonly routerService = core.getService(RouterService);
 
   @property() participant: ParticipantProfileExtended|undefined = undefined;
@@ -66,7 +69,13 @@ export class ParticipantSummary extends MobxLitElement {
     } else if (this.experimentManager.isObsoleteParticipant(this.participant)) {
       return html`<div class="chip">${this.participant.currentStatus}</div>`;
     }
-    // TODO: else if in transfer stage, return "ready for transfer" chip
+
+    // If in transfer stage, return "ready for transfer" chip
+    const stage = this.experimentService.getStage(this.participant.currentStageId);
+    if (stage.kind === StageKind.TRANSFER) {
+      return html`<div class="chip tertiary">ready for transfer!</div>`;
+    }
+
     return nothing;
   }
 

--- a/frontend/src/components/participant_previewer/participant_previewer.ts
+++ b/frontend/src/components/participant_previewer/participant_previewer.ts
@@ -6,6 +6,7 @@ import '../stages/chat_panel';
 import '../stages/info_view';
 import '../stages/survey_view';
 import '../stages/tos_view';
+import '../stages/transfer_view';
 import './participant_nav';
 
 import {MobxLitElement} from '@adobe/lit-mobx';
@@ -182,6 +183,12 @@ export class ParticipantPreviewer extends MobxLitElement {
         return html`
           <div class="content">
             <survey-view .stage=${stage} .answer=${answer}></survey-view>
+          </div>
+        `;
+      case StageKind.TRANSFER:
+        return html`
+          <div class="content">
+            <transfer-view .stage=${stage}></transfer-view>
           </div>
         `;
       default:

--- a/frontend/src/components/popup/accept_transfer_popup.ts
+++ b/frontend/src/components/popup/accept_transfer_popup.ts
@@ -58,22 +58,10 @@ class TransferPopup extends MobxLitElement {
   private async handleNo() {
     if (!this.participantService.profile) return;
 
-    await this.participantService.updateProfile({
-      ...this.participantService.profile,
-      currentStatus: ParticipantStatus.TRANSFER_DECLINED
-    });
-
-    const prolificConfig = this.experimentService.experiment?.prolificConfig;
-    if (prolificConfig?.enableProlificIntegration) {
-      // Navigate to Prolific with completion code.
-      window.location.href = PROLIFIC_COMPLETION_URL_PREFIX
-        + prolificConfig.defaultRedirectCode;
-    } else {
-      this.routerService.navigate(Pages.PARTICIPANT, {
-        'experiment': this.routerService.activeRoute.params['experiment'],
-        'participant': this.routerService.activeRoute.params['participant']
-      });
-    }
+    await this.participantService.updateExperimentFailure(
+      ParticipantStatus.TRANSFER_DECLINED,
+      true
+    );
   }
 }
 

--- a/frontend/src/components/popup/attention_check_popup.ts
+++ b/frontend/src/components/popup/attention_check_popup.ts
@@ -4,9 +4,6 @@ import {customElement, property, state} from 'lit/decorators.js';
 import {core} from '../../core/core';
 import {ExperimentService} from '../../services/experiment.service';
 import {ParticipantService} from '../../services/participant.service';
-import {Pages, RouterService} from '../../services/router.service';
-import {PROLIFIC_COMPLETION_URL_PREFIX} from '../../shared/constants';
-
 import {
   ParticipantStatus
 } from '@deliberation-lab/utils';
@@ -19,7 +16,6 @@ class AttentionPopup extends MobxLitElement {
 
   private readonly experimentService = core.getService(ExperimentService);
   private readonly participantService = core.getService(ParticipantService);
-  private readonly routerService = core.getService(RouterService);
 
   @property({type: Number})
   waitSeconds: number = 60; // Default value of 60 seconds
@@ -102,20 +98,10 @@ class AttentionPopup extends MobxLitElement {
     this.showAttentionCheck = false;
     alert('Attention check failed.');
 
-    await this.participantService.submitAttentionCheckFailure();
-    const config = this.experimentService.experiment?.prolificConfig;
-
-    if (config && config.enableProlificIntegration) {
-      const code = config.attentionFailRedirectCode.length > 0 ?
-        config.attentionFailRedirectCode : config.defaultRedirectCode;
-      // Navigate to Prolific with completion code
-      window.location.href = PROLIFIC_COMPLETION_URL_PREFIX + code;
-    } else {
-      this.routerService.navigate(Pages.PARTICIPANT, {
-        'experiment': this.routerService.activeRoute.params['experiment'],
-        'participant': this.routerService.activeRoute.params['participant']
-      });
-    }
+    await this.participantService.updateExperimentFailure(
+      ParticipantStatus.ATTENTION_TIMEOUT,
+      true
+    );
   };
 
   render() {

--- a/frontend/src/components/stages/transfer_editor.scss
+++ b/frontend/src/components/stages/transfer_editor.scss
@@ -1,0 +1,35 @@
+@use "../../sass/colors";
+@use "../../sass/common";
+@use "../../sass/typescale";
+
+:host {
+  @include common.flex-column;
+  gap: common.$spacing-xxl;
+}
+
+.section {
+  @include common.flex-column;
+  gap: common.$spacing-large;
+}
+
+pr-textarea {
+  flex-grow: 1;
+  width: 100%;
+}
+
+.checkbox-wrapper {
+  @include common.flex-row-align-center;
+  gap: common.$spacing-small;
+  overflow-wrap: break-word;
+
+  md-checkbox {
+    flex-shrink: 0;
+  }
+}
+
+.number-input {
+  @include common.number-input;
+  /* width of checkbox plus gap */
+  margin-left: calc(48px + common.$spacing-medium);
+  width: max-content;
+}

--- a/frontend/src/components/stages/transfer_editor.ts
+++ b/frontend/src/components/stages/transfer_editor.ts
@@ -1,0 +1,104 @@
+import '../../pair-components/textarea';
+
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+
+import '@material/web/checkbox/checkbox.js';
+
+import {core} from '../../core/core';
+import {ExperimentEditor} from '../../services/experiment.editor';
+
+import {
+  TransferStageConfig,
+  StageKind,
+} from '@deliberation-lab/utils';
+
+import {styles} from './transfer_editor.scss';
+
+/** Editor for transfer stage. */
+@customElement('transfer-editor')
+export class TransferEditorComponent extends MobxLitElement {
+  static override styles: CSSResultGroup = [styles];
+
+  private readonly experimentEditor = core.getService(ExperimentEditor);
+
+  @property() stage: TransferStageConfig|undefined = undefined;
+
+  override render() {
+    if (this.stage === undefined) {
+      return nothing;
+    }
+
+    return html`
+      ${this.renderTimeout()}
+    `;
+  }
+
+  private renderTimeout() {
+    if (!this.stage) return;
+    const isTimeout = this.stage.enableTimeout;
+
+    const updateTimeout = () => {
+      if (!this.stage) return;
+      const enableTimeout = !isTimeout;
+      this.experimentEditor.updateStage({ ...this.stage, enableTimeout });
+    };
+
+    return html`
+      <div class="section">
+        <div class="title">Timeout</div>
+        <div class="description">
+          Note: If timeout is enabled and the experimenter does not transfer
+          the participant within the timeout window, the participant is removed
+          from the experiment with TIMEOUT_FAILED status
+        </div>
+        <div class="checkbox-wrapper">
+          <md-checkbox
+            touch-target="wrapper"
+            ?checked=${isTimeout}
+            @click=${updateTimeout}
+          >
+          </md-checkbox>
+          <div>
+            Enable timeout window
+          </div>
+        </div>
+        ${isTimeout ? this.renderTimeoutSeconds() : nothing}
+      </div>
+    `;
+  }
+
+  private renderTimeoutSeconds() {
+    if (!this.stage) return nothing;
+    const waitSeconds = this.stage.timeoutSeconds;
+    const updateNum = (e: InputEvent) => {
+      if (!this.stage) return;
+      const timeoutSeconds = Number((e.target as HTMLTextAreaElement).value);
+      this.experimentEditor.updateStage({ ...this.stage, timeoutSeconds });
+    };
+
+    return html`
+      <div class="number-input">
+        <label for="waitSeconds">
+          Timeout window (in seconds) before transfer stage ends
+        </label>
+        <input
+          type="number"
+          id="waitSeconds"
+          name="waitSeconds"
+          min="0"
+          .value=${waitSeconds}
+          @input=${updateNum}
+        />
+      </div>
+    `;
+  }
+
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'transfer-editor': TransferEditorComponent;
+  }
+}

--- a/frontend/src/components/stages/transfer_view.scss
+++ b/frontend/src/components/stages/transfer_view.scss
@@ -1,0 +1,13 @@
+@use "../../sass/common";
+@use "../../sass/typescale";
+
+:host {
+  @include common.flex-column;
+  gap: common.$spacing-xl;
+  height: 100%;
+}
+
+.overlay {
+  @include common.overlay;
+  opacity: 0;
+}

--- a/frontend/src/components/stages/transfer_view.ts
+++ b/frontend/src/components/stages/transfer_view.ts
@@ -1,0 +1,117 @@
+import './stage_description';
+
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {CSSResultGroup, html, nothing} from 'lit';
+import {customElement, property, state} from 'lit/decorators.js';
+
+import {core} from '../../core/core';
+import {AuthService} from '../../services/auth.service';
+import {ParticipantService} from '../../services/participant.service';
+import {
+  ParticipantStatus,
+  TransferStageConfig
+} from '@deliberation-lab/utils';
+
+import {styles} from './transfer_view.scss';
+
+/** Transfer stage view for participants. */
+@customElement('transfer-view')
+export class TransferView extends MobxLitElement {
+  static override styles: CSSResultGroup = [styles];
+
+  private readonly authService = core.getService(AuthService);
+  private readonly participantService = core.getService(ParticipantService);
+
+  @property() stage: TransferStageConfig | null = null;
+
+  // Timeout states
+  @state() countdownInterval: number|undefined = undefined;
+  @state() timeRemainingSeconds: number = 600;
+
+  connectedCallback() {
+    super.connectedCallback();
+    // If timeout, start countdown
+    if (this.stage?.enableTimeout) {
+      this.startCountdown();
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.clearCountdown();
+  }
+
+  override render() {
+    if (!this.stage) {
+      return nothing;
+    }
+
+    return html`
+      <stage-description .stage=${this.stage}></stage-description>
+      ${this.renderCountdown()}
+      ${this.renderOverlay()}
+    `;
+  }
+
+  private renderOverlay() {
+    if (!this.stage?.enableTimeout
+      || this.participantService.completedStage(this.stage.id ?? '')
+      || this.authService.isExperimenter) return;
+
+    // Temporary solution: Prevent participant from clicking to other
+    // stages and resetting the transfer countdown
+    return html`<div class="overlay"></div>`;
+  }
+
+  private renderCountdown() {
+    if (!this.countdownInterval) return;
+
+    return html`
+      <div>Time remaining: ${this.timeRemainingSeconds} seconds</div>
+    `;
+  }
+
+  handleTimedOut() {
+    this.clearCountdown();
+
+    // Don't end experiment if experiment is already over
+    // or if experimenter is previewing
+    if (this.authService.isExperimenter
+      || this.participantService.completedStage(this.stage?.id ?? '')) {
+      return;
+    }
+
+    alert('Thanks for waiting. The experiment has ended.');
+    this.participantService.updateExperimentFailure(
+      ParticipantStatus.TRANSFER_TIMEOUT,
+      true
+    );
+  }
+
+  startCountdown() {
+    this.clearCountdown(); // Ensure no previous intervals are running
+    if (this.stage) {
+      this.timeRemainingSeconds = this.stage.timeoutSeconds;
+    }
+      this.countdownInterval = window.setInterval(() => {
+      if (this.timeRemainingSeconds > 0) {
+        this.timeRemainingSeconds -= 1;
+      } else {
+        this.handleTimedOut();
+      }
+    }, 1000);
+  }
+
+  clearCountdown() {
+    if (this.countdownInterval !== undefined) {
+      window.clearInterval(this.countdownInterval);
+      this.countdownInterval = undefined;
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'transfer-view': TransferView;
+  }
+}

--- a/frontend/src/services/participant.service.ts
+++ b/frontend/src/services/participant.service.ts
@@ -118,6 +118,10 @@ export class ParticipantService extends Service {
     return this.completedExperiment || !this.isCurrentStage()
   }
 
+  completedStage(stageId: string) {
+    return this.profile?.timestamps.completedStages[stageId];
+  }
+
   @computed get completedExperiment() {
     return this.profile?.currentStatus !== ParticipantStatus.IN_PROGRESS
   }

--- a/frontend/src/services/participant.service.ts
+++ b/frontend/src/services/participant.service.ts
@@ -124,6 +124,7 @@ export class ParticipantService extends Service {
 
   @computed get completedExperiment() {
     return this.profile?.currentStatus !== ParticipantStatus.IN_PROGRESS
+      && this.profile?.currentStatus !== ParticipantStatus.TRANSFER_PENDING
   }
 
   @computed get currentStageAnswer() {

--- a/frontend/src/services/participant.service.ts
+++ b/frontend/src/services/participant.service.ts
@@ -24,7 +24,7 @@ import {computed, makeObservable, observable} from 'mobx';
 import {CohortService} from './cohort.service';
 import {ExperimentService} from './experiment.service';
 import {FirebaseService} from './firebase.service';
-import {RouterService} from './router.service';
+import {Pages,RouterService} from './router.service';
 import {SurveyService} from './survey.service';
 import {Service} from './service';
 
@@ -33,6 +33,7 @@ import {
   updateParticipantCallable,
   updateSurveyStageParticipantAnswerCallable,
 } from '../shared/callables';
+import {PROLIFIC_COMPLETION_URL_PREFIX} from '../shared/constants';
 
 interface ServiceProvider {
   cohortService: CohortService;
@@ -201,7 +202,7 @@ export class ParticipantService extends Service {
   // FIRESTORE                                                               //
   // *********************************************************************** //
 
-  /** Save last stage and complete experiment. */
+  /** Save last stage and complete experiment with success. */
   async completeLastStage() {
     if (!this.profile) {
       return;
@@ -233,26 +234,46 @@ export class ParticipantService extends Service {
     );
   }
 
-  /** Submit attention check failure. */
-  async submitAttentionCheckFailure() {
+  /** End experiment due to failure. */
+  async updateExperimentFailure(
+    currentStatus: ParticipantStatus,
+    navigateToFailurePage = false
+  ) {
     if (!this.profile) {
       return;
     }
 
+    // Update endExperiment timestamp and currentStatus
     const endExperiment = Timestamp.now();
     const timestamps = {
       ...this.profile.timestamps,
       endExperiment
     };
 
-    const currentStatus = ParticipantStatus.ATTENTION_TIMEOUT;
-    return await this.updateProfile(
+    await this.updateProfile(
       {
         ...this.profile,
         timestamps,
         currentStatus,
       }
     );
+
+    // Route to experiment landing (or redirect to Prolific)
+    if (!navigateToFailurePage) return;
+    const config = this.sp.experimentService.experiment?.prolificConfig;
+
+    if (config && config.enableProlificIntegration) {
+      const code = currentStatus === ParticipantStatus.ATTENTION_TIMEOUT
+        && config.attentionFailRedirectCode.length > 0 ?
+        config.attentionFailRedirectCode : config.defaultRedirectCode;
+      // Navigate to Prolific with completion code
+      window.location.href = PROLIFIC_COMPLETION_URL_PREFIX + code;
+    } else {
+      this.sp.routerService.navigate(Pages.PARTICIPANT, {
+        'experiment': this.experimentId!,
+        'participant': this.profile!.privateId,
+      });
+    }
   }
 
   /** Move to next stage. */

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -29,6 +29,8 @@ export * from './stages/survey_stage';
 export * from './stages/survey_stage.validation';
 export * from './stages/tos_stage';
 export * from './stages/tos_stage.validation';
+export * from './stages/transfer_stage';
+export * from './stages/transfer_stage.validation';
 
 // Utils
 export * from './utils/algebraic.utils';

--- a/utils/src/stages/stage.ts
+++ b/utils/src/stages/stage.ts
@@ -7,6 +7,7 @@ import {
   SurveyStagePublicData,
 } from './survey_stage';
 import { TOSStageConfig } from './tos_stage';
+import { TransferStageConfig } from './transfer_stage';
 
 /** Base stage types and functions. */
 
@@ -25,6 +26,7 @@ export enum StageKind {
   PAYOUT = 'payout',
   REVEAL = 'reveal',
   SURVEY = 'survey',
+  TRANSFER = 'transfer',
   WTL_SURVEY = 'wtlSurvey', // willingness to lead survey
 
   // Lost at Sea (LAS) game specific stages
@@ -63,7 +65,8 @@ export type StageConfig =
   | InfoStageConfig
   | ProfileStageConfig
   | SurveyStageConfig
-  | TOSStageConfig;
+  | TOSStageConfig
+  | TransferStageConfig;
 
 /**
  * Base stage answer created from participant input.

--- a/utils/src/stages/stage.validation.ts
+++ b/utils/src/stages/stage.validation.ts
@@ -4,6 +4,7 @@ import { ChatStageConfigData } from './chat_stage.validation';
 import { InfoStageConfigData } from './info_stage.validation';
 import { ProfileStageConfigData } from './profile_stage.validation';
 import { SurveyStageConfigData } from './survey_stage.validation';
+import { TransferStageConfigData } from './transfer_stage.validation';
 import { TOSStageConfigData } from './tos_stage.validation';
 
 // ************************************************************************* //
@@ -17,6 +18,7 @@ export const StageConfigData = Type.Union([
   ProfileStageConfigData,
   SurveyStageConfigData,
   TOSStageConfigData,
+  TransferStageConfigData,
 ]);
 
 /** StageGame input validation. */

--- a/utils/src/stages/transfer_stage.ts
+++ b/utils/src/stages/transfer_stage.ts
@@ -1,0 +1,38 @@
+import { generateId } from '../shared';
+import {
+  BaseStageConfig,
+  StageGame,
+  StageKind,
+  createStageTextConfig,
+} from './stage';
+
+/** Transfer stage types and functions. */
+
+// ************************************************************************* //
+// TYPES                                                                     //
+// ************************************************************************* //
+
+export interface TransferStageConfig extends BaseStageConfig {
+  kind: StageKind.TRANSFER;
+  enableTimeout: boolean;
+  timeoutSeconds: number;
+}
+
+// ************************************************************************* //
+// FUNCTIONS                                                                 //
+// ************************************************************************* //
+
+/** Create transfer stage. */
+export function createTransferStage(
+  config: Partial<TransferStageConfig> = {}
+): TransferStageConfig {
+  return {
+    id: config.id ?? generateId(),
+    kind: StageKind.TRANSFER,
+    game: config.game ?? StageGame.NONE,
+    name: config.name ?? 'Transfer',
+    descriptions: config.descriptions ?? createStageTextConfig(),
+    enableTimeout: config.enableTimeout ?? false,
+    timeoutSeconds: config.timeoutSeconds ?? 600, // 10 minutes
+  };
+}

--- a/utils/src/stages/transfer_stage.validation.ts
+++ b/utils/src/stages/transfer_stage.validation.ts
@@ -1,0 +1,24 @@
+import { Type, type Static } from '@sinclair/typebox';
+import { StageKind } from './stage';
+import { StageGameSchema, StageTextConfigSchema } from './stage.validation';
+
+/** Shorthand for strict TypeBox object validation */
+const strict = { additionalProperties: false } as const;
+
+// ************************************************************************* //
+// writeExperiment, updateStageConfig endpoints                              //
+// ************************************************************************* //
+
+/** TransferStageConfig input validation. */
+export const TransferStageConfigData = Type.Object(
+  {
+    id: Type.String({ minLength: 1 }),
+    kind: Type.Literal(StageKind.TRANSFER),
+    game: StageGameSchema,
+    name: Type.String({ minLength: 1 }),
+    descriptions: StageTextConfigSchema,
+    enableTimeout: Type.Boolean(),
+    timeoutSeconds: Type.Number(),
+  },
+  strict,
+);


### PR DESCRIPTION
During a transfer stage, participants wait (no "next stage" click option) for an experimenter to transfer them to a cohort. If a timeout is enabled, participants will be removed from the experiment at the end of the timeout window (which starts when the participant enters the transfer stage).